### PR TITLE
fix: inject PAPERCLIP_API_KEY from ctx.authToken into child process env

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -302,6 +302,11 @@ export async function execute(
   const taskId = cfgString(ctx.config?.taskId);
   if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
+  // Inject the per-run JWT so Hermes tools (terminal, execute_code) can
+  // authenticate against the Paperclip API via $PAPERCLIP_API_KEY.
+  // Without this, agents cannot call the API from curl or Python.
+  if (ctx.authToken) env.PAPERCLIP_API_KEY = ctx.authToken;
+
   const userEnv = config.env as Record<string, string> | undefined;
   if (userEnv && typeof userEnv === "object") {
     Object.assign(env, userEnv);


### PR DESCRIPTION
## Summary

- Injects `ctx.authToken` (per-run JWT) into the child process environment as `PAPERCLIP_API_KEY`
- Without this, Hermes agents cannot authenticate against the Paperclip API — every curl call returns 401

## Problem

The `execute()` function builds the environment for the spawned Hermes process but never sets `PAPERCLIP_API_KEY`, even though `ctx.authToken` is available on `AdapterExecutionContext`. This means:

- All curl commands to the Paperclip API return 401 Unauthorized
- Agents waste 3-5 tool calls per heartbeat discovering the auth failure
- Some agents (especially Haiku-tier) give up entirely, reporting "API blocked"
- Sonnet/Opus agents eventually work around it via env var scanning, but waste significant budget

## Fix

One line, mirroring `@paperclipai/adapter-claude-local` (line 170):

```typescript
if (ctx.authToken) env.PAPERCLIP_API_KEY = ctx.authToken;
```

## Test plan

- [x] Verified on Paperclip v2026.318.0 with 20 Hermes agents
- [x] After patching, agents authenticate on first curl call
- [x] Session persistence (`--resume`) continues to work
- [x] Both Haiku and Sonnet models tested

Fixes #2