### PR TITLE
feat: adapter 0.2.1 — bypass approval prompts, provider resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company",
   "type": "module",
   "license": "MIT",

--- a/src/server/detect-model.ts
+++ b/src/server/detect-model.ts
@@ -1,22 +1,33 @@
 /**
- * Detect the current model from the user's Hermes config.
+ * Detect the current model and provider from the user's Hermes config.
  *
- * Reads ~/.hermes/config.yaml and extracts the default model
- * and provider settings.
+ * Reads ~/.hermes/config.yaml and extracts the default model,
+ * provider, base_url, and api_mode settings.
+ *
+ * Also provides provider resolution logic that merges explicit config,
+ * Hermes config detection, and model-name prefix inference.
  */
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { MODEL_PREFIX_PROVIDER_HINTS, VALID_PROVIDERS } from "../shared/constants.js";
 
 export interface DetectedModel {
+  /** Model name from config (e.g. "gpt-5.4", "anthropic/claude-sonnet-4") */
   model: string;
+  /** Provider name from config (e.g. "copilot", "zai"). May be empty. */
   provider: string;
+  /** Base URL override from config (e.g. "https://api.githubcopilot.com"). May be empty. */
+  baseUrl: string;
+  /** API mode from config (e.g. "chat_completions", "codex_responses"). May be empty. */
+  apiMode: string;
+  /** Where the detection came from */
   source: "config";
 }
 
 /**
- * Read the Hermes config file and extract the default model.
+ * Read the Hermes config file and extract the default model config.
  */
 export async function detectModel(
   configPath?: string,
@@ -34,13 +45,15 @@ export async function detectModel(
 }
 
 /**
- * Parse model.default and model.provider from raw YAML content.
- * Uses simple regex parsing to avoid a YAML dependency.
+ * Parse model.default, model.provider, model.base_url, and model.api_mode
+ * from raw YAML content. Uses simple regex parsing to avoid a YAML dependency.
  */
 export function parseModelFromConfig(content: string): DetectedModel | null {
   const lines = content.split("\n");
   let model = "";
   let provider = "";
+  let baseUrl = "";
+  let apiMode = "";
   let inModelSection = false;
   let modelSectionIndent = 0;
 
@@ -67,11 +80,92 @@ export function parseModelFromConfig(content: string): DetectedModel | null {
         const val = match[2].trim().replace(/#.*$/, "").trim().replace(/^['"]|['"]$/g, "");
         if (key === "default") model = val;
         if (key === "provider") provider = val;
+        if (key === "base_url") baseUrl = val;
+        if (key === "api_mode") apiMode = val;
       }
     }
   }
 
   if (!model) return null;
 
-  return { model, provider, source: "config" };
+  return { model, provider, baseUrl, apiMode, source: "config" };
+}
+
+/**
+ * Infer a provider from the model name using prefix-based hints.
+ *
+ * For example:
+ *   "gpt-5.4"       → "copilot"
+ *   "claude-sonnet-4" → "anthropic"
+ *   "glm-5-turbo"   → "zai"
+ *
+ * Returns undefined if no hint matches (caller should fall back to "auto").
+ */
+export function inferProviderFromModel(model: string): string | undefined {
+  const lower = model.toLowerCase();
+
+  // Strip provider/ prefix if present (e.g. "anthropic/claude-sonnet-4")
+  const bareName = lower.includes("/") ? lower.split("/").pop()! : lower;
+
+  for (const [prefix, hint] of MODEL_PREFIX_PROVIDER_HINTS) {
+    if (bareName.startsWith(prefix)) {
+      return hint;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve the correct provider for a model, using a priority chain:
+ *
+ *   1. Explicit provider from adapterConfig (highest priority — user override)
+ *   2. Provider from Hermes config file — ONLY if the config model matches
+ *      the requested model (otherwise the config provider is for a different model)
+ *   3. Provider inferred from model name prefix
+ *   4. "auto" (let Hermes figure it out — lowest priority)
+ *
+ * Always returns a valid provider string.
+ * The `resolvedFrom` field indicates which source was used, useful for logging.
+ */
+export function resolveProvider(options: {
+  /** Explicit provider from adapterConfig (user override) */
+  explicitProvider?: string | null;
+  /** Provider detected from Hermes config file */
+  detectedProvider?: string;
+  /** Model name from Hermes config file (to check consistency) */
+  detectedModel?: string;
+  /** Model name to infer from if no explicit/detected provider */
+  model?: string;
+}): { provider: string; resolvedFrom: string } {
+  const { explicitProvider, detectedProvider, detectedModel, model } = options;
+
+  // 1. Explicit provider from adapterConfig — user override, always wins
+  if (explicitProvider && (VALID_PROVIDERS as readonly string[]).includes(explicitProvider)) {
+    return { provider: explicitProvider, resolvedFrom: "adapterConfig" };
+  }
+
+  // 2. Provider from Hermes config file — but ONLY if the config model matches
+  //    the requested model. Otherwise the config provider is for a different model
+  //    and would cause exactly the kind of routing bug we're fixing.
+  if (
+    detectedProvider &&
+    detectedModel &&
+    (VALID_PROVIDERS as readonly string[]).includes(detectedProvider) &&
+    // Config model matches requested model (exact or case-insensitive)
+    detectedModel.toLowerCase() === model?.toLowerCase()
+  ) {
+    return { provider: detectedProvider, resolvedFrom: "hermesConfig" };
+  }
+
+  // 3. Infer from model name prefix
+  if (model) {
+    const inferred = inferProviderFromModel(model);
+    if (inferred) {
+      return { provider: inferred, resolvedFrom: "modelInference" };
+    }
+  }
+
+  // 4. Let Hermes auto-detect
+  return { provider: "auto", resolvedFrom: "auto" };
 }

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -14,6 +14,8 @@
  *   -w/--worktree      isolated git worktree
  *   -v/--verbose       verbose output
  *   --checkpoints      filesystem checkpoints
+ *   --yolo             bypass dangerous-command approval prompts (agents have no TTY)
+ *   --source           session source tag for filtering
  */
 
 import type {
@@ -33,8 +35,14 @@ import {
   HERMES_CLI,
   DEFAULT_TIMEOUT_SEC,
   DEFAULT_GRACE_SEC,
+  DEFAULT_MODEL,
   VALID_PROVIDERS,
 } from "../shared/constants.js";
+
+import {
+  detectModel,
+  resolveProvider,
+} from "./detect-model.js";
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -308,8 +316,7 @@ export async function execute(
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
-  const model = cfgString(config.model);
-  const provider = cfgString(config.provider);
+  const model = cfgString(config.model) || DEFAULT_MODEL;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
@@ -317,6 +324,34 @@ export async function execute(
   const persistSession = cfgBoolean(config.persistSession) !== false;
   const worktreeMode = cfgBoolean(config.worktreeMode) === true;
   const checkpoints = cfgBoolean(config.checkpoints) === true;
+
+  // ── Resolve provider (defense in depth) ────────────────────────────────
+  // Priority chain:
+  //   1. Explicit provider in adapterConfig (user override)
+  //   2. Provider from ~/.hermes/config.yaml (detected at runtime)
+  //   3. Provider inferred from model name prefix
+  //   4. "auto" (let Hermes decide)
+  //
+  // This ensures that even if the agent was created before provider tracking
+  // was added, or if the model was changed without updating provider, the
+  // correct provider is still used.
+  let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
+  const explicitProvider = cfgString(config.provider);
+
+  if (!explicitProvider) {
+    try {
+      detectedConfig = await detectModel();
+    } catch {
+      // Non-fatal — detection failure shouldn't block execution
+    }
+  }
+
+  const { provider: resolvedProvider, resolvedFrom } = resolveProvider({
+    explicitProvider,
+    detectedProvider: detectedConfig?.provider,
+    detectedModel: detectedConfig?.model,
+    model,
+  });
 
   // ── Build prompt ───────────────────────────────────────────────────────
   const prompt = buildPrompt(ctx, config);
@@ -331,9 +366,10 @@ export async function execute(
     args.push("-m", model);
   }
 
-  // Only pass --provider if it's a valid Hermes provider choice.
-  if (provider && (VALID_PROVIDERS as readonly string[]).includes(provider)) {
-    args.push("--provider", provider);
+  // Always pass --provider when we have a resolved one (not "auto").
+  // "auto" means Hermes will decide on its own — no need to pass it.
+  if (resolvedProvider !== "auto") {
+    args.push("--provider", resolvedProvider);
   }
 
   if (toolsets) {
@@ -347,6 +383,13 @@ export async function execute(
   // Tag sessions as "tool" source so they don't clutter the user's session history.
   // Requires hermes-agent >= PR #3255 (feat/session-source-tag).
   args.push("--source", "tool");
+
+  // Bypass Hermes dangerous-command approval prompts.
+  // Paperclip agents run as non-interactive subprocesses with no TTY,
+  // so approval prompts would always timeout and deny legitimate commands
+  // (curl, python3 -c, etc.). Agents operate in a sandbox — the approval
+  // system is designed for human-attended interactive sessions.
+  args.push("--yolo");
 
   // Session resume
   const prevSessionId = cfgString(
@@ -387,7 +430,7 @@ export async function execute(
   // ── Log start ──────────────────────────────────────────────────────────
   await ctx.onLog(
     "stdout",
-    `[hermes] Starting Hermes Agent (model=${model ?? "configured-default"}, timeout=${timeoutSec}s)\n`,
+    `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s)\n`,
   );
   if (prevSessionId) {
     await ctx.onLog(
@@ -444,8 +487,8 @@ export async function execute(
     exitCode: result.exitCode,
     signal: result.signal,
     timedOut: result.timedOut,
-    provider: provider || null,
-    model: model || null,
+    provider: resolvedProvider,
+    model,
   };
 
   if (parsed.errorMessage) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@
 
 export { execute } from "./execute.js";
 export { testEnvironment } from "./test.js";
-export { detectModel } from "./detect-model.js";
+export { detectModel, parseModelFromConfig, resolveProvider, inferProviderFromModel } from "./detect-model.js";
 export {
   listHermesSkills as listSkills,
   syncHermesSkills as syncSkills,

--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -14,7 +14,8 @@ import type {
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-import { HERMES_CLI, ADAPTER_TYPE } from "../shared/constants.js";
+import { HERMES_CLI, DEFAULT_MODEL, ADAPTER_TYPE, VALID_PROVIDERS } from "../shared/constants.js";
+import { detectModel, resolveProvider, inferProviderFromModel } from "./detect-model.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -148,12 +149,14 @@ function checkApiKeys(
   const hasOpenRouter = has("OPENROUTER_API_KEY");
   const hasOpenAI = has("OPENAI_API_KEY");
   const hasZai = has("ZAI_API_KEY");
+  const hasKimi = has("KIMI_API_KEY");
+  const hasMiniMax = has("MINIMAX_API_KEY");
 
-  if (!hasAnthropic && !hasOpenRouter && !hasOpenAI && !hasZai) {
+  if (!hasAnthropic && !hasOpenRouter && !hasOpenAI && !hasZai && !hasKimi && !hasMiniMax) {
     return {
       level: "warn",
       message: "No LLM API keys found in environment",
-      hint: "Set ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, or ZAI_API_KEY in the agent's env secrets. Hermes may also have keys configured in ~/.hermes/.env",
+      hint: "Set API keys in the agent's env secrets or ~/.hermes/.env. Hermes supports: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, ZAI_API_KEY, KIMI_API_KEY, MINIMAX_API_KEY",
       code: "hermes_no_api_keys",
     };
   }
@@ -163,12 +166,74 @@ function checkApiKeys(
   if (hasOpenRouter) providers.push("OpenRouter");
   if (hasOpenAI) providers.push("OpenAI");
   if (hasZai) providers.push("Z.AI");
+  if (hasKimi) providers.push("Kimi");
+  if (hasMiniMax) providers.push("MiniMax");
 
   return {
     level: "info",
     message: `API keys found: ${providers.join(", ")}`,
     code: "hermes_api_keys_found",
   };
+}
+
+/**
+ * Check provider/model consistency.
+ * Warns if the configured provider might be wrong for the model.
+ */
+async function checkProviderConsistency(
+  config: Record<string, unknown>,
+): Promise<AdapterEnvironmentCheck | null> {
+  const model = asString(config.model);
+  if (!model) return null;
+
+  const explicitProvider = asString(config.provider);
+
+  // Try to detect from Hermes config
+  let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
+  try {
+    detectedConfig = await detectModel();
+  } catch {
+    // Non-fatal
+  }
+
+  const { provider: resolved, resolvedFrom } = resolveProvider({
+    explicitProvider,
+    detectedProvider: detectedConfig?.provider,
+    detectedModel: detectedConfig?.model,
+    model,
+  });
+
+  // If provider was explicitly set but doesn't match what Hermes config says,
+  // that's worth flagging.
+  if (explicitProvider && detectedConfig?.provider && explicitProvider !== detectedConfig.provider) {
+    return {
+      level: "warn",
+      message: `Provider mismatch: adapterConfig has "${explicitProvider}" but ~/.hermes/config.yaml has "${detectedConfig.provider}". Using adapterConfig value.`,
+      hint: `Model "${model}" may not work correctly with provider "${explicitProvider}". Consider aligning with your Hermes config or removing the explicit provider to use auto-detection.`,
+      code: "hermes_provider_mismatch",
+    };
+  }
+
+  // If provider was auto-detected (not explicitly set), log what was resolved
+  if (!explicitProvider && resolvedFrom !== "auto") {
+    return {
+      level: "info",
+      message: `Provider auto-detected as "${resolved}" (from ${resolvedFrom}) for model "${model}"`,
+      code: "hermes_provider_detected",
+    };
+  }
+
+  // If we couldn't resolve any provider, warn
+  if (resolvedFrom === "auto" && !explicitProvider) {
+    return {
+      level: "warn",
+      message: `Could not determine provider for model "${model}" — will use Hermes auto-detection`,
+      hint: "Set an explicit provider in the agent config or ensure ~/.hermes/config.yaml has a matching provider for this model.",
+      code: "hermes_provider_unknown",
+    };
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -211,6 +276,10 @@ export async function testEnvironment(
   // 5. API keys (check config.env — server resolves secrets before calling us)
   const apiKeyCheck = checkApiKeys(config);
   if (apiKeyCheck) checks.push(apiKeyCheck);
+
+  // 6. Provider/model consistency
+  const providerCheck = await checkProviderConsistency(config);
+  if (providerCheck) checks.push(providerCheck);
 
   // Determine overall status
   const hasErrors = checks.some((c) => c.level === "error");

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -22,18 +22,63 @@ export const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
 
 /**
  * Valid --provider choices for the hermes CLI.
- * When not specified, Hermes auto-detects from model name.
+ * Must stay in sync with `hermes chat --help`.
  */
 export const VALID_PROVIDERS = [
   "auto",
   "openrouter",
   "nous",
   "openai-codex",
+  "copilot",
+  "copilot-acp",
+  "anthropic",
+  "huggingface",
   "zai",
   "kimi-coding",
   "minimax",
   "minimax-cn",
+  "kilocode",
 ] as const;
+
+/**
+ * Model-name prefix → provider hint mapping.
+ * Used when no explicit provider is configured and we need to infer
+ * the correct provider from the model string alone.
+ *
+ * Keys are lowercased prefix patterns; values must be valid provider names.
+ * Longer prefixes are matched first (order matters).
+ */
+export const MODEL_PREFIX_PROVIDER_HINTS: [string, string][] = [
+  // OpenAI-native models
+  ["gpt-4", "openai-codex"],
+  ["gpt-5", "copilot"],
+  ["o1-", "openai-codex"],
+  ["o3-", "openai-codex"],
+  ["o4-", "openai-codex"],
+  // Anthropic models
+  ["claude", "anthropic"],
+  // Google models (via openrouter or direct)
+  ["gemini", "auto"],
+  // Nous models
+  ["hermes-", "nous"],
+  // Z.AI / GLM models
+  ["glm-", "zai"],
+  // Kimi / Moonshot
+  ["moonshot", "kimi-coding"],
+  ["kimi", "kimi-coding"],
+  // MiniMax
+  ["minimax", "minimax"],
+  // DeepSeek
+  ["deepseek", "auto"],
+  // Meta Llama
+  ["llama", "auto"],
+  // Qwen
+  ["qwen", "auto"],
+  // Mistral
+  ["mistral", "auto"],
+  // HuggingFace models (org/model format)
+  ["huggingface/", "huggingface"],
+];
 
 /** Regex to extract session ID from Hermes CLI output. */
 export const SESSION_ID_REGEX = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -3,6 +3,11 @@
  *
  * Translates Paperclip's CreateConfigValues into the adapterConfig
  * object stored in the agent record.
+ *
+ * NOTE: Provider resolution happens at runtime in execute.ts, not here.
+ * The UI may or may not pass a provider field. If it does, we persist it
+ * as the user's explicit override. If not, execute.ts will detect it from
+ * ~/.hermes/config.yaml at runtime.
  */
 
 import type { CreateConfigValues } from "@paperclipai/adapter-utils";
@@ -23,6 +28,17 @@ export function buildHermesConfig(
   if (v.model.trim()) {
     ac.model = v.model.trim();
   }
+
+  // NOTE: Provider is NOT set here because the Paperclip UI form
+  // (CreateConfigValues) does not expose a provider field.
+  // Instead, provider is resolved at runtime in execute.ts using
+  // a priority chain:
+  //   1. adapterConfig.provider (if set via API directly)
+  //   2. ~/.hermes/config.yaml detection
+  //   3. Model-name prefix inference
+  //   4. "auto" fallback
+  // This ensures correct provider routing even for agents created
+  // before provider tracking existed.
 
   // Execution limits
   ac.timeoutSec = DEFAULT_TIMEOUT_SEC;


### PR DESCRIPTION
## Summary

Two post-0.2.0 improvements.

### Fix: Bypass approval prompts for non-interactive agent sessions

Paperclip agents run as non-interactive subprocesses with no TTY. Hermes unconditionally sets `HERMES_INTERACTIVE=1` in `cli.py`, which routes all sessions through the dangerous-command approval flow. Without a TTY, the approval prompt times out and denies legitimate commands like `curl -s`, `python3 -c "..."`, etc.

This PR passes `--yolo` to `hermes chat`, which sets `HERMES_YOLO_MODE=1` and bypasses the approval flow. This is the correct semantic — the approval system is designed for human-attended interactive sessions, not autonomous agent subprocesses.

**Root cause:** `cli.py:7454` sets `HERMES_INTERACTIVE=1` unconditionally (even for piped/non-TTY invocations). Could be fixed upstream with a `sys.stdin.isatty()` guard.

### Feat: Provider resolution with defense-in-depth priority chain

Previously, the adapter read the provider from `adapterConfig.provider` or fell back to "auto". This caused routing bugs when:
- An agent was created before provider tracking existed
- The model was changed without updating the provider
- Hermes config had a provider set for a *different* model

New 4-level priority chain:
1. **adapterConfig.provider** — explicit user override (highest)
2. **~/.hermes/config.yaml** — detected provider, but ONLY when config model matches the requested model
3. **Model-name prefix inference** — e.g. `claude-sonnet-4` → `anthropic`, `glm-5-turbo` → `zai`
4. **"auto"** — let Hermes decide (lowest)

Also adds 5 new providers (copilot, copilot-acp, anthropic, huggingface, kilocode) and improves env diagnostics.

## Files changed (7)

| File | Change |
|------|--------|
| `package.json` | Version bump 0.2.0 → 0.2.1 |
| `src/shared/constants.ts` | New providers + model prefix hints table |
| `src/server/detect-model.ts` | `resolveProvider()`, `inferProviderFromModel()`, enhanced config parsing |
| `src/server/execute.ts` | `--yolo` flag, provider resolution chain, improved logs |
| `src/server/index.ts` | Export new functions |
| `src/server/test.ts` | Kimi/MiniMax key checks, new `checkProviderConsistency` |
| `src/ui/build-config.ts` | Documentation comments on provider flow |