### PR TITLE
fix: respect timeoutSec=0 instead of falling back to 300s default

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -317,8 +317,8 @@ export async function execute(
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
   const model = cfgString(config.model) || DEFAULT_MODEL;
-  const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
-  const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
+  const timeoutSec = cfgNumber(config.timeoutSec) ?? DEFAULT_TIMEOUT_SEC;
+  const graceSec = cfgNumber(config.graceSec) ?? DEFAULT_GRACE_SEC;
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
   const extraArgs = cfgStringArray(config.extraArgs);
   const persistSession = cfgBoolean(config.persistSession) !== false;

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -40,8 +40,9 @@ export function buildHermesConfig(
   // This ensures correct provider routing even for agents created
   // before provider tracking existed.
 
-  // Execution limits
-  ac.timeoutSec = DEFAULT_TIMEOUT_SEC;
+  // Execution limits — use the form value when provided, otherwise default
+  const formTimeout = (v as unknown as Record<string, unknown>).timeoutSec;
+  ac.timeoutSec = (typeof formTimeout === "number" && formTimeout >= 0) ? formTimeout : DEFAULT_TIMEOUT_SEC;
   // maxTurnsPerRun maps to Hermes's max_turns (set via config, not CLI flag)
 
   // Session persistence (default: on)


### PR DESCRIPTION
## Summary

- **execute.ts**: Change `||` to `??` when reading `timeoutSec` and `graceSec` from adapter config. `0` is a valid value meaning "no timeout", but `||` treats it as falsy and falls back to `DEFAULT_TIMEOUT_SEC` (300s). Using `??` (nullish coalescing) only falls back when the value is `null`/`undefined`.
- **build-config.ts**: Read `timeoutSec` from the Paperclip UI form values instead of unconditionally hardcoding `DEFAULT_TIMEOUT_SEC`. This ensures new agents created through the UI respect the timeout field in the "Permissions & Configuration" section.

## Test plan

- [ ] Create a new Hermes agent via the Paperclip UI with timeout set to 0 → verify the run starts with `timeout=0s` (no timeout)
- [ ] Create a new Hermes agent with timeout set to 600 → verify `timeout=600s`
- [ ] Create a new Hermes agent with timeout left blank → verify it defaults to 300s
- [ ] Edit an existing agent's timeout to 0, trigger a run → verify no timeout applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)