### PR TITLE
fix: make timeout configurable, raise default to 1800s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company",
   "type": "module",
   "license": "MIT",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -319,6 +319,7 @@ export async function execute(
   const model = cfgString(config.model) || DEFAULT_MODEL;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
+  const maxTurns = cfgNumber(config.maxTurnsPerRun);
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
   const extraArgs = cfgStringArray(config.extraArgs);
   const persistSession = cfgBoolean(config.persistSession) !== false;
@@ -376,6 +377,10 @@ export async function execute(
     args.push("-t", toolsets);
   }
 
+  if (maxTurns && maxTurns > 0) {
+    args.push("--max-turns", String(maxTurns));
+  }
+
   if (worktreeMode) args.push("-w");
   if (checkpoints) args.push("--checkpoints");
   if (cfgBoolean(config.verbose) === true) args.push("-v");
@@ -430,7 +435,7 @@ export async function execute(
   // ── Log start ──────────────────────────────────────────────────────────
   await ctx.onLog(
     "stdout",
-    `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s)\n`,
+    `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
   );
   if (prevSessionId) {
     await ctx.onLog(

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -12,7 +12,7 @@ export const ADAPTER_LABEL = "Hermes Agent";
 export const HERMES_CLI = "hermes";
 
 /** Default timeout for a single execution run (seconds). */
-export const DEFAULT_TIMEOUT_SEC = 300;
+export const DEFAULT_TIMEOUT_SEC = 1800;
 
 /** Grace period after SIGTERM before SIGKILL (seconds). */
 export const DEFAULT_GRACE_SEC = 10;

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -40,9 +40,16 @@ export function buildHermesConfig(
   // This ensures correct provider routing even for agents created
   // before provider tracking existed.
 
-  // Execution limits
+  // Execution limits — let the user configure these from the Paperclip UI.
+  // timeoutSec: wall-clock kill timeout for the hermes child process.
+  // maxTurnsPerRun: maps to Hermes's --max-turns (agent tool-calling iterations).
   ac.timeoutSec = DEFAULT_TIMEOUT_SEC;
-  // maxTurnsPerRun maps to Hermes's max_turns (set via config, not CLI flag)
+  if (v.maxTurnsPerRun > 0) {
+    ac.maxTurnsPerRun = v.maxTurnsPerRun;
+    // Scale timeout to match: ~20s per tool turn is generous headroom.
+    // Never go below the default (1800s / 30 min).
+    ac.timeoutSec = Math.max(DEFAULT_TIMEOUT_SEC, v.maxTurnsPerRun * 20);
+  }
 
   // Session persistence (default: on)
   ac.persistSession = true;


### PR DESCRIPTION
## Problem

`buildHermesConfig()` hardcoded `timeoutSec = 300` (5 min), which was too short for complex agent tasks and not configurable from the Paperclip UI.

Reported by @michaltakac.

## Changes

| File | Change |
|------|--------|
| `constants.ts` | `DEFAULT_TIMEOUT_SEC`: 300 → 1800 (30 min) |
| `build-config.ts` | Wire `v.maxTurnsPerRun` → `ac.maxTurnsPerRun`; scale timeout from turns |
| `execute.ts` | Read `maxTurnsPerRun` from config, pass `--max-turns N` to hermes CLI |

### Timeout scaling logic

When `maxTurnsPerRun` is set in the Paperclip UI:
- `maxTurnsPerRun` is persisted to adapterConfig and passed as `--max-turns` to hermes
- `timeoutSec` is scaled to `max(1800, maxTurnsPerRun * 20)` — generous headroom per turn
- When not set, falls back to 1800s default

### Dependency

Requires `hermes-agent` PR [NousResearch/hermes-agent#4314](https://github.com/NousResearch/hermes-agent/pull/4314) for the `--max-turns` CLI flag. Without it, the flag is silently ignored by older hermes versions (argparse unknown args in `-q` mode).

## Version

0.2.1 → 0.3.0 (behavior change: existing agents get longer default timeout)
