### PR TITLE
Fix: read wake context from ctx.context, not ctx.config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -129,14 +129,16 @@ function buildPrompt(
 ): string {
   const template = cfgString(config.promptTemplate) || DEFAULT_PROMPT_TEMPLATE;
 
-  const taskId = cfgString(ctx.config?.taskId);
-  const taskTitle = cfgString(ctx.config?.taskTitle) || "";
-  const taskBody = cfgString(ctx.config?.taskBody) || "";
-  const commentId = cfgString(ctx.config?.commentId) || "";
-  const wakeReason = cfgString(ctx.config?.wakeReason) || "";
+  // Read wake context from ctx.context (not ctx.config which holds adapter settings)
+  const context = (ctx.context ?? {}) as Record<string, unknown>;
+  const taskId = cfgString(context.taskId) || cfgString(context.issueId);
+  const taskTitle = cfgString(context.taskTitle) || "";
+  const taskBody = cfgString(context.taskBody) || "";
+  const commentId = cfgString(context.commentId) || cfgString(context.wakeCommentId);
+  const wakeReason = cfgString(context.wakeReason) || "";
   const agentName = ctx.agent?.name || "Hermes Agent";
-  const companyName = cfgString(ctx.config?.companyName) || "";
-  const projectName = cfgString(ctx.config?.projectName) || "";
+  const companyName = cfgString(context.companyName) || "";
+  const projectName = cfgString(context.projectName) || "";
 
   // Build API URL — ensure it has the /api path
   let paperclipApiUrl =
@@ -415,7 +417,9 @@ export async function execute(
   };
 
   if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
-  const taskId = cfgString(ctx.config?.taskId);
+  // Read taskId from ctx.context (wake context), not ctx.config (adapter settings)
+  const context = (ctx.context ?? {}) as Record<string, unknown>;
+  const taskId = cfgString(context.taskId) || cfgString(context.issueId);
   if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
   const userEnv = config.env as Record<string, string> | undefined;


### PR DESCRIPTION
## Problem

The adapter was reading wake context (taskId, taskTitle, taskBody, commentId, wakeReason) from `ctx.config` instead of `ctx.context`.

`ctx.config` holds adapter configuration settings (workspaceDir, paperclipApiUrl, etc.).

`ctx.context` holds the wake context passed by Paperclip when an agent is triggered (taskId, taskTitle, taskBody, commentId, wakeReason, etc.).

## Impact

When an agent was assigned a task or mentioned in a comment:
1. The prompt template would never receive the taskId → `{{#taskId}}` section was empty
2. Fell through to `{{#noTask}}` heartbeat behavior
3. Agent would scan for unassigned issues instead of working on the assigned task
4. No `PAPERCLIP_TASK_ID` env var was set

## Fix

Changed both locations that read wake context to read from `ctx.context`:
- `buildPrompt()` function (lines 132-139)
- `execute()` function for PAPERCLIP_TASK_ID env var (line 418)

Also added fallback support for `issueId` and `wakeCommentId` aliases.

## Testing

Fix applied locally and Paperclip server restarted. The next wake should correctly receive task context.

Fixes OVE-36.