### PR TITLE
fix: remove python3 -c json.loads from prompt templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -99,7 +99,8 @@ Title: {{taskTitle}}
 ## Comment on This Issue
 
 Someone commented. Read it:
-   \`curl -s "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}" | python3 -m json.tool\`
+   \`curl -s "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}"\`
+   Then format the JSON output yourself for readability.
 
 Address the comment, POST a reply if needed, then continue working.
 {{/commentId}}
@@ -108,7 +109,8 @@ Address the comment, POST a reply if needed, then continue working.
 ## Heartbeat Wake — Check for Work
 
 1. List ALL open issues assigned to you (todo, backlog, in_progress):
-   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
+   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}"\`
+   Then parse the JSON response and display each issue as: IDENTIFIER STATUS PRIORITY TITLE
 
 2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
    - Read the issue details: \`curl -s "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
@@ -116,7 +118,8 @@ Address the comment, POST a reply if needed, then continue working.
    - When done, mark complete and post a comment (see Workflow steps 2-4 above)
 
 3. If no issues assigned to you, check for unassigned issues:
-   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
+   \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog"\`
+   Then parse the JSON response and display unassigned issues as: IDENTIFIER TITLE
    If you find a relevant issue, assign it to yourself:
    \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
 


### PR DESCRIPTION
## Problem

The Hermes agent adapter hardcodes inline Python one-liners in the system prompt:

    curl -s "..." | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());..."

These get passed as literal text to the Hermes agent via role_template + roleOverride. The agent then tries to **execute them as shell commands**, producing errors like:

    File "<stdin>", line 1
        =json.loads(sys.stdin.read())
         ^SyntaxError: invalid syntax

This explains the `issues=json.loads(sys.stdin.read())` errors visible in CEO run logs.

## Fix

Replaced all 3 instances in execute.ts with plain curl + instruction for the agent to parse JSON output itself:

- Comment notification: removed `| python3 -m json.tool` pipelining
- Heartbeat issue list: removed python3 -c json.loads pipeline, added manual parse instruction
- Unassigned issue scan: same pattern

Agents are capable of parsing JSON from curl output without python3 piping.

## Testing

    grep -n "python3.*-c.*json.loads" dist/server/execute.js
    # (empty — all instances removed)

Compiled output confirmed clean. Deployed to Paperclip node_modules.
