### PR TITLE
fix: use comment field in PATCH body for issue completion

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -87,11 +87,11 @@ Title: {{taskTitle}}
 ## Workflow
 
 1. Work on the task using your tools
-2. When done, mark the issue as completed:
-   \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/{{taskId}}" -H "Content-Type: application/json" -d '{"status":"done"}'\`
-3. Post a completion comment on the issue summarizing what you did:
-   \`curl -s -X POST "{{paperclipApiUrl}}/issues/{{taskId}}/comments" -H "Content-Type: application/json" -d '{"body":"DONE: <your summary here>"}'\`
-4. If this issue has a parent (check the issue body or comments for references like TRA-XX), post a brief notification on the parent issue so the parent owner knows:
+2. When done, mark the issue as completed AND post the result in a single call:
+   \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/{{taskId}}" -H "Content-Type: application/json" -d "{\"status\":\"done\",\"comment\":\"DONE: <your summary of what was accomplished>"}'\`
+
+   NOTE: The \`comment\` field is displayed in the Paperclip UI and is the primary way results reach the user. Always include your actual output (haiku, code, list, etc.) in the \`comment\` field — do NOT rely on separate POST to /comments.
+3. If this issue has a parent (check the issue body or comments for references like TRA-XX), post a brief notification on the parent issue:
    \`curl -s -X POST "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments" -H "Content-Type: application/json" -d '{"body":"{{agentName}} completed {{taskId}}. Summary: <brief>"}'\`
 {{/taskId}}
 
@@ -113,7 +113,7 @@ Address the comment, POST a reply if needed, then continue working.
 2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
    - Read the issue details: \`curl -s "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
    - Do the work in the project directory: {{projectName}}
-   - When done, mark complete and post a comment (see Workflow steps 2-4 above)
+   - When done, mark complete and post a comment (see Workflow step 2 above)
 
 3. If no issues assigned to you, check for unassigned issues:
    \`curl -s "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`


### PR DESCRIPTION
## Problem

The `DEFAULT_PROMPT_TEMPLATE` instructed Hermes to:
1. PATCH `{"status":"done"}` to mark the issue complete
2. POST a separate comment to `/issues/{{taskId}}/comments`

Hermes frequently skips the second API call (as observed — it only sent `{"status":"done"}`), so results are never posted and the UI shows nothing.

## Fix

Collapse the workflow into a single PATCH with the `comment` field in the body:

```bash
curl -s -X PATCH "{{paperclipApiUrl}}/issues/{{taskId}}" \
  -H "Content-Type: application/json" \
  -d '{"status":"done","comment":"DONE: <summary of what was accomplished>"}'
```

The Paperclip API accepts `comment` in the PATCH body and renders it in the issue thread. One call instead of two, and results are guaranteed to appear.

Also updated the heartbeat wake section which referenced the old step numbers (steps 2-4 → step 2).