### PR TITLE
fix: forward onSpawn callback to child process runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "lint": "eslint src/",
+    "test": "node --test test/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -476,6 +476,7 @@ export async function execute(
     timeoutSec,
     graceSec,
     onLog: wrappedOnLog,
+    onSpawn: ctx.onSpawn,
   });
 
   // ── Parse output ───────────────────────────────────────────────────────

--- a/test/execute-onspawn.test.mjs
+++ b/test/execute-onspawn.test.mjs
@@ -1,0 +1,12 @@
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const source = await readFile(new URL('../src/server/execute.ts', import.meta.url), 'utf8');
+
+test('execute forwards ctx.onSpawn to runChildProcess', () => {
+  assert.match(
+    source,
+    /runChildProcess\(ctx\.runId,\s*hermesCmd,\s*args,\s*\{[\s\S]*?onSpawn:\s*ctx\.onSpawn,[\s\S]*?\}\);/m,
+  );
+});


### PR DESCRIPTION
## Summary
- Pass `ctx.onSpawn` into `runChildProcess` so Paperclip persists `processPid` for Hermes child runs
- Add a regression test asserting `execute.ts` forwards the callback
- Wire `npm test` to Node's built-in test runner

## Test Plan
- `npm test`
- `npm run typecheck`

## Context
Without `onSpawn`, Hermes child runs can remain `processPid=null` and get incorrectly reaped as `process_lost`.