### PR TITLE
fix: fall back to config.command when hermesCommand is missing

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -315,7 +315,9 @@ export async function execute(
   const config = (ctx.config ?? ctx.agent?.adapterConfig ?? {}) as Record<string, unknown>;
 
   // ── Resolve configuration ──────────────────────────────────────────────
-  const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
+  // Accept both "hermesCommand" (canonical, written by buildHermesConfig) and
+  // "command" (legacy — written by older UI versions or direct API callers).
+  const hermesCmd = cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
   const model = cfgString(config.model) || DEFAULT_MODEL;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;


### PR DESCRIPTION
## Summary

- `execute.ts` reads `config.hermesCommand` for the Hermes binary, but the UI edit path and direct API callers write the field as `config.command`
- When `hermesCommand` is missing, the adapter silently falls back to the default `hermes` binary, ignoring custom profile wrappers (e.g. `hermes_maximus`)
- One-line fix: add `config.command` as a fallback before `HERMES_CLI`

## Problem

`buildHermesConfig()` correctly translates `v.command` → `ac.hermesCommand` on agent **creation**, but the UI update path writes the raw field name `command` back to `adapterConfig`. Agents created via direct API calls also use `command`.

`execute.ts` line 318:
```typescript
// Before (broken — misses config.command)
const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;

// After (works — checks both field names)
const hermesCmd = cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
```

## How we found it

A Paperclip Hermes agent ("CEO - Maximus") was configured with `command: "hermes_maximus"` pointing to a profile wrapper script. Sessions consistently landed in `~/.hermes/sessions/` (default home) instead of `~/.hermes/profiles/hermes_maximus/sessions/`. Tracing through `execute.ts` revealed the field name mismatch.

## Test plan

- [ ] Agent with `adapterConfig.command = "hermes_maximus"` spawns `hermes_maximus` instead of `hermes`
- [ ] Agent with `adapterConfig.hermesCommand = "hermes_maximus"` still works (no regression)
- [ ] Agent with neither field falls back to default `hermes` binary

Fixes #24

Related: #20, #22