### PR TITLE
Improve Hermes thinking/tool states in Paperclip

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "lint": "eslint src/",
+    "test": "npm run build && node --test test/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -1,7 +1,7 @@
 /**
  * Server-side execution logic for the Hermes Agent adapter.
  *
- * Spawns `hermes chat -q "..." -Q` as a child process, streams output,
+ * Spawns `hermes chat -q "..."` as a child process, streams output,
  * and returns structured results to Paperclip.
  *
  * Verified CLI flags (hermes chat):
@@ -358,8 +358,9 @@ export async function execute(
   const prompt = buildPrompt(ctx, config);
 
   // ── Build command args ─────────────────────────────────────────────────
-  // Use -Q (quiet) to get clean output: just response + session_id line
-  const useQuiet = cfgBoolean(config.quiet) !== false; // default true
+  // Default to non-quiet mode so Paperclip receives live [tool], ┊ 💭, and
+  // ┊ 💬 lines. Callers can still opt into quiet mode with adapterConfig.quiet=true.
+  const useQuiet = cfgBoolean(config.quiet) === true; // default false
   const args: string[] = ["chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -69,7 +69,7 @@ function cfgStringArray(v: unknown): string[] | undefined {
 
 const DEFAULT_PROMPT_TEMPLATE = `You are "{{agentName}}", an AI agent employee in a Paperclip-managed company.
 
-IMPORTANT: Use \`terminal\` tool with \`curl\` for ALL Paperclip API calls (web_extract and browser cannot access localhost).
+IMPORTANT: Use \`terminal\` tool with \`curl\` for ALL Paperclip API calls. Keep commands short and avoid Python heredocs/formatters unless there is no practical curl-only alternative.
 
 Your Paperclip identity:
   Agent ID: {{agentId}}
@@ -86,41 +86,28 @@ Title: {{taskTitle}}
 
 ## Workflow
 
-1. Work on the task using your tools
-2. When done, mark the issue as completed:
-   \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}" -H "Content-Type: application/json" -d '{"status":"done"}'\`
-3. Post a completion comment on the issue summarizing what you did:
-   \`curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments" -H "Content-Type: application/json" -d '{"body":"DONE: <your summary here>"}'\`
-4. If this issue has a parent (check the issue body or comments for references like TRA-XX), post a brief notification on the parent issue so the parent owner knows:
-   \`curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments" -H "Content-Type: application/json" -d '{"body":"{{agentName}} completed {{taskId}}. Summary: <brief>"}'\`
+1. Read task context and work on the issue using your tools.
+2. Update the issue when you are done or blocked:
+   \`curl -s -X PATCH "{{paperclipApiUrl}}/issues/{{taskId}}" -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -H "Content-Type: application/json" -d '{"status":"done","comment":"BLUF: done. <summary>"}'\`
+3. If this issue has a parent, add one short parent notification comment:
+   \`curl -s -X POST "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments" -H "Authorization: Bearer $PAPERCLIP_API_KEY" -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" -H "Content-Type: application/json" -d '{"body":"BLUF: {{agentName}} finished {{taskId}}. <summary>"}'\`
 {{/taskId}}
 
 {{#commentId}}
 ## Comment on This Issue
 
-Someone commented. Read it:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}" | python3 -m json.tool\`
-
-Address the comment, POST a reply if needed, then continue working.
+Someone commented. Read the issue and comment, then reply or continue work:
+   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}"\`
 {{/commentId}}
 
 {{#noTask}}
 ## Heartbeat Wake — Check for Work
 
-1. List ALL open issues assigned to you (todo, backlog, in_progress):
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
-
-2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
-   - Read the issue details: \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
-   - Do the work in the project directory: {{projectName}}
-   - When done, mark complete and post a comment (see Workflow steps 2-4 above)
-
-3. If no issues assigned to you, check for unassigned issues:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
-   If you find a relevant issue, assign it to yourself:
-   \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
-
-4. If truly nothing to do, report briefly what you checked.
+1. List open issues assigned to you:
+   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}"\`
+2. If issues exist, work on the highest-priority in_progress or todo issue. Read details with:
+   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
+3. If no issues are assigned, do not search unassigned backlog work. Report briefly what you checked and exit.
 {{/noTask}}`;
 
 function buildPrompt(

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -54,6 +54,10 @@ export function buildHermesConfig(
   // Session persistence (default: on)
   ac.persistSession = true;
 
+  // Keep Hermes in non-quiet mode by default so Paperclip receives incremental
+  // [tool], ┊ 💭, and ┊ 💬 lines and can render live progress states.
+  ac.quiet = false;
+
   // Working directory
   if (v.cwd) {
     ac.cwd = v.cwd;

--- a/src/ui/parse-stdout.ts
+++ b/src/ui/parse-stdout.ts
@@ -1,14 +1,18 @@
 /**
  * Parse Hermes Agent stdout into TranscriptEntry objects for the Paperclip UI.
  *
- * Hermes CLI quiet-mode output patterns:
- *   Assistant:  "  ┊ 💬 {text}"
- *   Tool (TTY): "  ┊ {emoji} {verb:9} {detail}  {duration}"
- *   Tool (pipe): "  [done] ┊ {emoji} {verb:9} {detail}  {duration} ({total})"
- *   System:     "[hermes] ..."
+ * Hermes CLI output patterns:
+ *   Assistant:   "  ┊ 💬 {text}"
+ *   Thinking:    "  ┊ 💭 {text}"
+ *   Tool start:  "  [tool] (｡◕‿◕｡) 💻 $   curl -s \"...\""
+ *   Tool done:   "  ┊ 💻 $   curl -s \"...\"  0.1s"
+ *   Tool done:   "  [done] ┊ 💻 $   curl -s \"...\"  0.1s (0.5s)"
+ *   System:      "[hermes] ..."
  *
- * We emit structured tool_call/tool_result pairs so Paperclip renders proper
- * tool cards (with status icons, expand/collapse) instead of raw stdout blocks.
+ * We emit tool_call when a [tool] start line appears, then emit the matching
+ * tool_result when the completion line arrives. If a completion line arrives
+ * without a pending start line (for example in quiet mode), we synthesize both
+ * entries from that single line as a fallback.
  */
 
 import type { TranscriptEntry } from "@paperclipai/adapter-utils";
@@ -23,8 +27,19 @@ import { TOOL_OUTPUT_PREFIX } from "../shared/constants.js";
  * by only stripping parenthesized kaomoji like (｡◕‿◕｡).
  */
 function stripKaomoji(text: string): string {
-  // Strip parenthesized kaomoji faces: (｡◕‿◕｡), (★ω★), etc.
   return text.replace(/[(][^()]{2,20}[)]\s*/gu, "").trim();
+}
+
+function stripFramePrefix(line: string): string {
+  let cleaned = line.trim().replace(/^\[done\]\s*/, "").replace(/^\[tool\]\s*/, "");
+  if (cleaned.startsWith(TOOL_OUTPUT_PREFIX)) {
+    cleaned = cleaned.slice(TOOL_OUTPUT_PREFIX.length);
+  }
+  return stripKaomoji(cleaned).trim();
+}
+
+function isEmojiToken(token: string): boolean {
+  return /^(?:\p{Extended_Pictographic}|\p{Emoji_Presentation})/u.test(token);
 }
 
 // ── Line classification ────────────────────────────────────────────────────
@@ -39,114 +54,133 @@ function extractAssistantText(line: string): string {
   return line.replace(/^[\s┊]*💬\s*/, "").trim();
 }
 
-/**
- * Parse a tool completion line into structured data.
- *
- * Handles both TTY and pipe formats:
- *   TTY:  ┊ 💻 $         curl -s "..."  0.1s
- *   Pipe: [done] ┊ 💻 $   curl -s "..."  0.1s (0.5s)
- */
-function parseToolCompletionLine(
+function isPipeOutputLine(trimmed: string): boolean {
+  return (
+    trimmed.startsWith(TOOL_OUTPUT_PREFIX) ||
+    /^\[done\]\s*┊/.test(trimmed)
+  );
+}
+
+function isSpinnerNoiseLine(line: string): boolean {
+  const stripped = stripFramePrefix(line);
+  return /^\p{Emoji_Presentation}\s*(Completed|Running|Error)?\s*$/u.test(stripped);
+}
+
+// ── Tool parsing ───────────────────────────────────────────────────────────
+
+interface ParsedToolLine {
+  name: string;
+  detail: string;
+  duration: string;
+  hasError: boolean;
+}
+
+const TOOL_NAME_MAP: Record<string, string> = {
+  "$": "shell",
+  exec: "shell",
+  terminal: "shell",
+  search: "search",
+  fetch: "fetch",
+  crawl: "crawl",
+  navigate: "browser",
+  snapshot: "browser",
+  click: "browser",
+  type: "browser",
+  scroll: "browser",
+  back: "browser",
+  press: "browser",
+  close: "browser",
+  images: "browser",
+  vision: "browser",
+  read: "read",
+  write: "write",
+  patch: "patch",
+  grep: "search",
+  find: "search",
+  plan: "plan",
+  recall: "recall",
+  proc: "process",
+  delegate: "delegate",
+  todo: "todo",
+  memory: "memory",
+  clarify: "clarify",
+  session_search: "recall",
+  code: "execute",
+  execute: "execute",
+  web_search: "search",
+  web_extract: "fetch",
+  browser_navigate: "browser",
+  browser_click: "browser",
+  browser_type: "browser",
+  browser_snapshot: "browser",
+  browser_vision: "browser",
+  browser_scroll: "browser",
+  browser_press: "browser",
+  browser_back: "browser",
+  browser_close: "browser",
+  browser_get_images: "browser",
+  read_file: "read",
+  write_file: "write_file",
+  search_files: "search",
+  patch_file: "patch",
+  execute_code: "execute",
+};
+
+function normalizeToolDetail(detail: string): string {
+  return detail
+    .replace(/\s+/g, " ")
+    .replace(/\s*\[(?:exit \d+|error|full)\]\s*$/i, "")
+    .trim();
+}
+
+function parseToolLine(
   line: string,
-): { name: string; detail: string; duration: string; hasError: boolean } | null {
-  // Strip leading whitespace and [done] prefix
-  let cleaned = line.trim().replace(/^\[done\]\s*/, "");
+  options: { parseDuration?: boolean } = {},
+): ParsedToolLine | null {
+  const cleaned = stripFramePrefix(line);
+  if (!cleaned) return null;
+  if (cleaned.startsWith("💬") || cleaned.startsWith("💭")) return null;
 
-  // Must start with ┊
-  if (!cleaned.startsWith(TOOL_OUTPUT_PREFIX)) return null;
-
-  // Remove ┊ prefix and any leading kaomoji face
-  cleaned = cleaned.slice(TOOL_OUTPUT_PREFIX.length);
-  cleaned = stripKaomoji(cleaned).trim();
-
-  // Now format is: "{emoji} {verb:9} {detail}  {duration}" or "{emoji} {verb:9} {detail}  {duration} ({total})"
-  // Example: "💻 $         curl -s ..." or "🔍 search    pattern  0.1s"
-  // The verb+detail are separated by whitespace, duration is at the end
-
-  // Match: emoji + verb + detail + duration
-  // Duration pattern: N.Ns (possibly followed by (N.Ns))
-  const durationMatch = cleaned.match(/([\d.]+s)\s*(?:\([\d.]+s\))?\s*$/);
-  const duration = durationMatch ? durationMatch[1] : "";
-
-  // Remove duration from the end to get verb + detail
-  let verbAndDetail = durationMatch
+  const durationMatch = options.parseDuration
+    ? cleaned.match(/([\d.]+s)\s*(?:\([\d.]+s\))?\s*$/)
+    : null;
+  const duration = durationMatch?.[1] ?? "";
+  const withoutDuration = durationMatch
     ? cleaned.slice(0, cleaned.lastIndexOf(durationMatch[0])).trim()
     : cleaned;
 
-  // Check for error suffixes
-  const hasError = /\[(?:exit \d+|error|full)\]/.test(verbAndDetail) ||
-    /\[error\]\s*$/.test(cleaned);
+  const hasError =
+    /\[(?:exit \d+|error|full)\]\s*$/i.test(withoutDuration) ||
+    /\[error\]\s*$/i.test(cleaned);
 
-  // The first token (after emoji) is the verb, rest is detail
-  // Verbs are always a single word or symbol ($ for terminal)
-  const parts = verbAndDetail.match(/^(\S+)\s+(.*)/);
-  if (!parts) {
-    return { name: "tool", detail: verbAndDetail, duration, hasError };
+  const tokens = withoutDuration.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+
+  let verb = tokens[0];
+  let detailTokens = tokens.slice(1);
+
+  if (tokens.length >= 2 && isEmojiToken(tokens[0])) {
+    verb = tokens[1];
+    detailTokens = tokens.slice(2);
   }
 
-  const verb = parts[1];
-  const detail = parts[2].trim();
-
-  // Map Hermes verbs to readable tool names
-  const nameMap: Record<string, string> = {
-    "$": "shell",
-    "exec": "shell",
-    "terminal": "shell",
-    "search": "search",
-    "fetch": "fetch",
-    "crawl": "crawl",
-    "navigate": "browser",
-    "snapshot": "browser",
-    "click": "browser",
-    "type": "browser",
-    "scroll": "browser",
-    "back": "browser",
-    "press": "browser",
-    "close": "browser",
-    "images": "browser",
-    "vision": "browser",
-    "read": "read",
-    "write": "write",
-    "patch": "patch",
-    "grep": "search",
-    "find": "search",
-    "plan": "plan",
-    "recall": "recall",
-    "proc": "process",
-    "delegate": "delegate",
-    "todo": "todo",
-    "memory": "memory",
-    "clarify": "clarify",
-    "session_search": "recall",
-    "code": "execute",
-    "execute": "execute",
-    "web_search": "search",
-    "web_extract": "fetch",
-    "browser_navigate": "browser",
-    "browser_click": "browser",
-    "browser_type": "browser",
-    "browser_snapshot": "browser",
-    "browser_vision": "browser",
-    "browser_scroll": "browser",
-    "browser_press": "browser",
-    "browser_back": "browser",
-    "browser_close": "browser",
-    "browser_get_images": "browser",
-    "read_file": "read",
-    "write_file": "write_file",
-    "search_files": "search",
-    "patch_file": "patch",
-    "execute_code": "execute",
-  };
-
-  const name = nameMap[verb.toLowerCase()] || verb;
+  const detail = detailTokens.join(" ").trim();
+  const name = TOOL_NAME_MAP[verb.toLowerCase()] || verb;
 
   return { name, detail, duration, hasError };
 }
 
-// ── Synthetic tool ID generation ────────────────────────────────────────────
+// ── Synthetic tool ID generation + pending tool tracking ───────────────────
 
 let toolCallCounter = 0;
+
+interface PendingToolCall {
+  id: string;
+  name: string;
+  detail: string;
+}
+
+const pendingToolCalls: PendingToolCall[] = [];
 
 /**
  * Generate a synthetic toolUseId for pairing tool_call with tool_result.
@@ -156,15 +190,46 @@ function syntheticToolUseId(): string {
   return `hermes-tool-${++toolCallCounter}`;
 }
 
+function clearPendingToolCalls(): void {
+  pendingToolCalls.length = 0;
+}
+
+function enqueuePendingToolCall(name: string, detail: string): string {
+  const id = syntheticToolUseId();
+  pendingToolCalls.push({ id, name, detail: normalizeToolDetail(detail) });
+  return id;
+}
+
+function takePendingToolCall(name: string, detail: string): string | undefined {
+  if (pendingToolCalls.length === 0) return undefined;
+
+  const normalizedDetail = normalizeToolDetail(detail);
+  const exactIdx = pendingToolCalls.findIndex(
+    (pending) =>
+      pending.name === name &&
+      (pending.detail === normalizedDetail ||
+        pending.detail.startsWith(normalizedDetail) ||
+        normalizedDetail.startsWith(pending.detail)),
+  );
+
+  const idx = exactIdx >= 0 ? exactIdx : 0;
+  return pendingToolCalls.splice(idx, 1)[0]?.id;
+}
+
 // ── Thinking detection ─────────────────────────────────────────────────────
 
 function isThinkingLine(line: string): boolean {
+  const stripped = stripFramePrefix(line);
   return (
-    line.includes("💭") ||
-    line.startsWith("<thinking>") ||
-    line.startsWith("</thinking>") ||
-    line.startsWith("Thinking:")
+    stripped.startsWith("💭") ||
+    stripped.startsWith("<thinking>") ||
+    stripped.startsWith("</thinking>") ||
+    stripped.startsWith("Thinking:")
   );
+}
+
+function extractThinkingText(line: string): string {
+  return stripFramePrefix(line).replace(/^💭\s*/, "").trim();
 }
 
 // ── Main parser ────────────────────────────────────────────────────────────
@@ -172,8 +237,8 @@ function isThinkingLine(line: string): boolean {
 /**
  * Parse a single line of Hermes stdout into transcript entries.
  *
- * Emits structured tool_call/tool_result pairs (with synthetic IDs) so
- * Paperclip renders proper tool cards with status icons and expand/collapse.
+ * Emits structured tool_call and tool_result entries so Paperclip renders
+ * progress incrementally instead of collapsing everything into raw stdout.
  *
  * @param line  Raw stdout line from Hermes CLI
  * @param ts    ISO timestamp for the entry
@@ -188,14 +253,10 @@ export function parseHermesStdoutLine(
 
   // ── System/adapter messages ────────────────────────────────────────────
   if (trimmed.startsWith("[hermes]") || trimmed.startsWith("[paperclip]")) {
+    if (trimmed.startsWith("[hermes] Starting Hermes Agent")) {
+      clearPendingToolCalls();
+    }
     return [{ kind: "system", ts, text: trimmed }];
-  }
-
-  // ── Non-quiet mode tool start lines: [tool] (kaomoji) emoji verb ... ──
-  // These are redundant — the tool_call/tool_result pair arrives later from
-  // the ┊ completion line. Skip them to avoid duplicate entries.
-  if (trimmed.startsWith("[tool]")) {
-    return [];
   }
 
   // ── MCP / server init noise reclassified from stderr by wrappedOnLog ──
@@ -205,67 +266,93 @@ export function parseHermesStdoutLine(
     return [{ kind: "stderr", ts, text: trimmed }];
   }
 
-  // ── Standalone spinner remnants: "💻 Completed", "💻\nCompleted", etc. ─
-  // These are non-quiet mode spinner frame leftovers — skip them.
-  if (/^\p{Emoji_Presentation}\s*(Completed|Running|Error)?\s*$/u.test(trimmed)) {
-    return [];
-  }
-
   // ── Session info line ────────────────────────────────────────────────
   if (trimmed.startsWith("session_id:")) {
     return [{ kind: "system", ts, text: trimmed }];
   }
 
-  // ── Quiet-mode tool/message lines (prefixed with ┊) ────────────────────
-  if (trimmed.includes(TOOL_OUTPUT_PREFIX)) {
+  // ── Standalone spinner remnants: "💻 Completed", "┊ 💻 Completed", etc. ─
+  if (isSpinnerNoiseLine(trimmed)) {
+    return [];
+  }
+
+  // ── Thinking blocks ────────────────────────────────────────────────────
+  // Detect before generic ┊ parsing so ┊ 💭 lines do not degrade to stdout.
+  if (isThinkingLine(trimmed)) {
+    return [
+      {
+        kind: "thinking",
+        ts,
+        text: extractThinkingText(trimmed),
+      },
+    ];
+  }
+
+  // ── Non-quiet mode tool start lines: [tool] (kaomoji) emoji verb ... ───
+  if (trimmed.startsWith("[tool]")) {
+    const toolInfo = parseToolLine(trimmed);
+    if (!toolInfo) return [];
+
+    const toolUseId = enqueuePendingToolCall(toolInfo.name, toolInfo.detail);
+    return [
+      {
+        kind: "tool_call",
+        ts,
+        name: toolInfo.name,
+        input: { detail: toolInfo.detail },
+        toolUseId,
+      },
+    ];
+  }
+
+  // ── Quiet/non-quiet completion + assistant lines (prefixed with ┊) ────
+  if (isPipeOutputLine(trimmed)) {
     // Assistant message: ┊ 💬 {text}
     if (isAssistantToolLine(trimmed)) {
       return [{ kind: "assistant", ts, text: extractAssistantText(trimmed) }];
     }
 
     // Tool completion: ┊ {emoji} {verb} {detail} {duration}
-    const toolInfo = parseToolCompletionLine(trimmed);
+    const toolInfo = parseToolLine(trimmed, { parseDuration: true });
     if (toolInfo) {
-      const id = syntheticToolUseId();
+      const toolUseId = takePendingToolCall(toolInfo.name, toolInfo.detail);
       const detailText = toolInfo.duration
         ? `${toolInfo.detail}  ${toolInfo.duration}`
         : toolInfo.detail;
 
+      if (toolUseId) {
+        return [
+          {
+            kind: "tool_result",
+            ts,
+            toolUseId,
+            content: detailText,
+            isError: toolInfo.hasError,
+          },
+        ];
+      }
+
+      const fallbackToolUseId = syntheticToolUseId();
       return [
         {
-          kind: "tool_call" as const,
+          kind: "tool_call",
           ts,
           name: toolInfo.name,
           input: { detail: toolInfo.detail },
-          toolUseId: id,
+          toolUseId: fallbackToolUseId,
         },
         {
-          kind: "tool_result" as const,
+          kind: "tool_result",
           ts,
-          toolUseId: id,
+          toolUseId: fallbackToolUseId,
           content: detailText,
           isError: toolInfo.hasError,
         },
-      ] as TranscriptEntry[];
+      ];
     }
 
     // Fallback: raw ┊ line that doesn't match tool format
-    const stripped = trimmed
-      .replace(/^\[done\]\s*/, "")
-      .replace(new RegExp(`^${TOOL_OUTPUT_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*`), "")
-      .trim();
-    return [{ kind: "stdout", ts, text: stripped }];
-  }
-
-  // ── Thinking blocks ────────────────────────────────────────────────────
-  if (isThinkingLine(trimmed)) {
-    return [
-      {
-        kind: "thinking",
-        ts,
-        text: trimmed.replace(/^💭\s*/, ""),
-      },
-    ];
+    return [{ kind: "stdout", ts, text: stripFramePrefix(trimmed) }];
   }
 
   // ── Error output ───────────────────────────────────────────────────────

--- a/src/ui/parse-stdout.ts
+++ b/src/ui/parse-stdout.ts
@@ -126,11 +126,27 @@ const TOOL_NAME_MAP: Record<string, string> = {
   execute_code: "execute",
 };
 
+const MAX_TOOL_DETAIL_CHARS = 180;
+
 function normalizeToolDetail(detail: string): string {
   return detail
     .replace(/\s+/g, " ")
     .replace(/\s*\[(?:exit \d+|error|full)\]\s*$/i, "")
     .trim();
+}
+
+function compactToolDetail(detail: string): string {
+  const normalized = normalizeToolDetail(detail)
+    .replace(/python3\s+-c\s+(['"]).*$/i, "python3 -c <inline script>")
+    .replace(/python3\s+-m\s+json\.tool\b.*$/i, "python3 -m json.tool")
+    .replace(/<<'?[A-Z0-9_]*'?\s*$/i, "<<'PY'")
+    .replace(/\bhttps?:\/\/[^\s"']{80,}/g, (url) => `${url.slice(0, 77)}…`);
+
+  if (normalized.length <= MAX_TOOL_DETAIL_CHARS) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, MAX_TOOL_DETAIL_CHARS - 1)}…`;
 }
 
 function parseToolLine(
@@ -299,7 +315,7 @@ export function parseHermesStdoutLine(
         kind: "tool_call",
         ts,
         name: toolInfo.name,
-        input: { detail: toolInfo.detail },
+        input: { detail: compactToolDetail(toolInfo.detail) },
         toolUseId,
       },
     ];
@@ -316,9 +332,10 @@ export function parseHermesStdoutLine(
     const toolInfo = parseToolLine(trimmed, { parseDuration: true });
     if (toolInfo) {
       const toolUseId = takePendingToolCall(toolInfo.name, toolInfo.detail);
+      const compactDetail = compactToolDetail(toolInfo.detail);
       const detailText = toolInfo.duration
-        ? `${toolInfo.detail}  ${toolInfo.duration}`
-        : toolInfo.detail;
+        ? `${compactDetail}  ${toolInfo.duration}`
+        : compactDetail;
 
       if (toolUseId) {
         return [
@@ -338,7 +355,7 @@ export function parseHermesStdoutLine(
           kind: "tool_call",
           ts,
           name: toolInfo.name,
-          input: { detail: toolInfo.detail },
+          input: { detail: compactToolDetail(toolInfo.detail) },
           toolUseId: fallbackToolUseId,
         },
         {

--- a/test/parse-stdout.test.mjs
+++ b/test/parse-stdout.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseHermesStdoutLine } from '../dist/ui/parse-stdout.js';
+
+const ts = '2026-04-04T18:00:00.000Z';
+
+test('parseHermesStdoutLine emits thinking, tool_start, and matching tool_result entries', () => {
+  assert.deepEqual(
+    parseHermesStdoutLine('[hermes] Starting Hermes Agent (model=alpine-alpha)', ts),
+    [{ kind: 'system', ts, text: '[hermes] Starting Hermes Agent (model=alpine-alpha)' }],
+  );
+
+  assert.deepEqual(
+    parseHermesStdoutLine('  ┊ 💭 Checking issue context', ts),
+    [{ kind: 'thinking', ts, text: 'Checking issue context' }],
+  );
+
+  const toolStart = parseHermesStdoutLine(
+    '[tool] (｡◕‿◕｡) 💻 $         curl -s "http://127.0.0.1:3100/api/issues/LUK-231"',
+    ts,
+  );
+
+  assert.equal(toolStart.length, 1);
+  assert.equal(toolStart[0].kind, 'tool_call');
+  assert.equal(toolStart[0].name, 'shell');
+  assert.equal(toolStart[0].input.detail, 'curl -s "http://127.0.0.1:3100/api/issues/LUK-231"');
+  assert.match(toolStart[0].toolUseId, /^hermes-tool-\d+$/);
+
+  assert.deepEqual(
+    parseHermesStdoutLine(
+      '  [done] ┊ 💻 $         curl -s "http://127.0.0.1:3100/api/issues/LUK-231"  0.1s (0.1s)',
+      ts,
+    ),
+    [
+      {
+        kind: 'tool_result',
+        ts,
+        toolUseId: toolStart[0].toolUseId,
+        content: 'curl -s "http://127.0.0.1:3100/api/issues/LUK-231"  0.1s',
+        isError: false,
+      },
+    ],
+  );
+});
+
+test('parseHermesStdoutLine preserves duration-like command args on [tool] start lines', () => {
+  parseHermesStdoutLine('[hermes] Starting Hermes Agent (model=alpine-alpha)', ts);
+
+  const entries = parseHermesStdoutLine('[tool] (｡◕‿◕｡) 💻 $         sleep 5s', ts);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].kind, 'tool_call');
+  assert.equal(entries[0].input.detail, 'sleep 5s');
+});
+
+test('parseHermesStdoutLine falls back to synthetic tool_call+tool_result when only a done line exists', () => {
+  parseHermesStdoutLine('[hermes] Starting Hermes Agent (model=alpine-alpha)', ts);
+
+  const entries = parseHermesStdoutLine(
+    '  [done] ┊ 💻 $         echo done  0.1s (0.1s)',
+    ts,
+  );
+
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].kind, 'tool_call');
+  assert.equal(entries[0].name, 'shell');
+  assert.equal(entries[0].input.detail, 'echo done');
+  assert.equal(entries[1].kind, 'tool_result');
+  assert.equal(entries[1].toolUseId, entries[0].toolUseId);
+  assert.equal(entries[1].content, 'echo done  0.1s');
+});

--- a/test/parse-stdout.test.mjs
+++ b/test/parse-stdout.test.mjs
@@ -54,6 +54,22 @@ test('parseHermesStdoutLine preserves duration-like command args on [tool] start
   assert.equal(entries[0].input.detail, 'sleep 5s');
 });
 
+test('parseHermesStdoutLine compacts python-heavy tool details', () => {
+  parseHermesStdoutLine('[hermes] Starting Hermes Agent (model=alpine-alpha)', ts);
+
+  const entries = parseHermesStdoutLine(
+    '[tool] (｡◕‿◕｡) 💻 $         curl -s "http://127.0.0.1:3100/api/issues/LUK-231/comments" | python3 -c "import sys,json; print(json.loads(sys.stdin.read()))"',
+    ts,
+  );
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].kind, 'tool_call');
+  assert.equal(
+    entries[0].input.detail,
+    'curl -s "http://127.0.0.1:3100/api/issues/LUK-231/comments" | python3 -c <inline script>',
+  );
+});
+
 test('parseHermesStdoutLine falls back to synthetic tool_call+tool_result when only a done line exists', () => {
   parseHermesStdoutLine('[hermes] Starting Hermes Agent (model=alpine-alpha)', ts);
 


### PR DESCRIPTION
## Summary

- default Hermes runs to non-quiet mode so Paperclip can receive live [tool], thinking, and assistant lines
- emit incremental tool_call/tool_result transcript events and classify thinking lines before generic stdout fallback
- reduce run-log command noise by simplifying the default Paperclip prompt and compacting Python-heavy tool details

## Validation

- npm test
- npm run typecheck
