### PR TITLE
fix: unwrap Paperclip secret-ref env vars before passing to child process

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -420,9 +420,15 @@ export async function execute(
   const taskId = cfgString(ctx.config?.taskId);
   if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
-  const userEnv = config.env as Record<string, string> | undefined;
+  const userEnv = config.env as Record<string, unknown> | undefined;
   if (userEnv && typeof userEnv === "object") {
-    Object.assign(env, userEnv);
+    for (const [key, val] of Object.entries(userEnv)) {
+      if (typeof val === "string") {
+        env[key] = val;
+      } else if (val && typeof val === "object" && typeof (val as any).value === "string") {
+        env[key] = (val as any).value;
+      }
+    }
   }
 
   // ── Resolve working directory ──────────────────────────────────────────

--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -139,7 +139,11 @@ function checkApiKeys(
   const envConfig = (config.env ?? {}) as Record<string, unknown>;
   const resolvedEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(envConfig)) {
-    if (typeof value === "string" && value.length > 0) resolvedEnv[key] = value;
+    if (typeof value === "string" && value.length > 0) {
+      resolvedEnv[key] = value;
+    } else if (value && typeof value === "object" && typeof (value as any).value === "string") {
+      resolvedEnv[key] = (value as any).value;
+    }
   }
 
   const has = (key: string): boolean =>


### PR DESCRIPTION
## Problem

Paperclip wraps env vars configured through `adapterConfig.env` as objects:

```json
{
  "ANTHROPIC_API_KEY": { "type": "plain", "value": "sk-ant-abc123..." },
  "HERMES_HOME": { "type": "plain", "value": "/home/user/.hermes/agent-1" }
}
```

The current code at `execute.ts:425` uses `Object.assign(env, userEnv)` which copies the **entire object** as the env var value. The spawned Hermes process then sees:

```
ANTHROPIC_API_KEY=[object Object]
HERMES_HOME=[object Object]
```

This breaks all env vars passed through Paperclip's `adapterConfig.env`, including API keys and working directories.

## Fix

Replace `Object.assign(env, userEnv)` with an iteration that:
- Passes plain strings through as-is (backwards-compatible)
- Unwraps `{ value: "..." }` objects to extract the actual string value

```typescript
for (const [key, val] of Object.entries(userEnv)) {
  if (typeof val === "string") {
    env[key] = val;
  } else if (val && typeof val === "object" && typeof (val as any).value === "string") {
    env[key] = (val as any).value;
  }
}
```

The same fix is applied to `checkApiKeys()` in `test.ts` so that `testEnvironment()` correctly detects API keys configured through Paperclip's secret management (without this fix, the env test reports "No LLM API keys found" even when keys are properly configured).

## Files Changed

- `src/server/execute.ts` — env var merging in `execute()`
- `src/server/test.ts` — env var resolution in `checkApiKeys()`

## How to Reproduce

1. Create a Hermes agent in Paperclip with env vars in `adapterConfig.env` (e.g., `ANTHROPIC_API_KEY`)
2. Trigger a heartbeat
3. The agent fails because all env vars are `[object Object]`

## Notes

Found while building [Gladiator](https://github.com/runtimenoteslabs/gladiator), a multi-agent competition project using Paperclip + Hermes for the Nous Research hackathon. We patched this locally in v0.1.1 (March 2026) and confirmed the bug persists through v0.3.0.