### PR TITLE
fix: add prepublishOnly to ensure dist is built before npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-paperclip-adapter",
   "version": "0.3.0",
-  "description": "Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company",
+  "description": "Paperclip adapter for Hermes Agent \u2014 run Hermes as a managed employee in a Paperclip company",
   "type": "module",
   "license": "MIT",
   "author": "Nous Research",
@@ -31,7 +31,8 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "^2026.325.0",


### PR DESCRIPTION
## Problem

The published v0.3.0 npm package contains a **stale `dist/`** that is missing the `ctx.authToken → PAPERCLIP_API_KEY` injection added in `src/server/execute.ts` (lines 418-419).

This causes Hermes agents running under Paperclip's **authenticated mode** to fail all API calls — they never receive the `PAPERCLIP_API_KEY` env var that the Paperclip server mints for each heartbeat run.

## Root Cause

`npm publish` does not run `tsc` automatically. The `dist/` directory included in the npm package was built from an older source version.

## Fix

Add `prepublishOnly: "npm run build"` to `package.json` scripts. This ensures `dist/` is always freshly compiled from `src/` before publishing.

## Verification

```bash
# Before fix (v0.3.0 from npm)
grep authToken node_modules/hermes-paperclip-adapter/dist/server/execute.js
# (no output — missing)

# After fix (rebuilt from source)
grep authToken dist/server/execute.js
# if (ctx.authToken && !env.PAPERCLIP_API_KEY)
#     env.PAPERCLIP_API_KEY = ctx.authToken;
```

## Impact

All `hermes_local` agents on Paperclip instances with `deploymentMode: "authenticated"` are affected. Agents fail to access the Paperclip API during heartbeats because the auth token is not injected into the environment.

The `opencode_local` adapter handles this correctly (`@paperclipai/adapter-opencode-local`) — this PR brings `hermes_local` to parity.

## Workaround (until fix is published)

Manually patch `dist/server/execute.js` after the `Object.assign(env, userEnv)` block:

```js
const hasExplicitApiKey = typeof userEnv?.PAPERCLIP_API_KEY === "string" && userEnv.PAPERCLIP_API_KEY.trim().length > 0;
if (!hasExplicitApiKey && ctx.authToken) {
    env.PAPERCLIP_API_KEY = ctx.authToken;
}
```