### PR TITLE
feat: comprehensive adapter parity — fix skills, billing, cost, profiles, barrel export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@paperclipai/adapter-utils": "^2026.325.0",
+        "@paperclipai/adapter-utils": "file:../paperclip/packages/adapter-utils",
         "picocolors": "^1.1.0"
       },
       "devDependencies": {
@@ -20,11 +20,18 @@
         "node": ">=20.0.0"
       }
     },
+    "../paperclip/packages/adapter-utils": {
+      "name": "@paperclipai/adapter-utils",
+      "version": "0.3.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.6.0",
+        "typescript": "^5.7.3"
+      }
+    },
     "node_modules/@paperclipai/adapter-utils": {
-      "version": "2026.325.0",
-      "resolved": "https://registry.npmjs.org/@paperclipai/adapter-utils/-/adapter-utils-2026.325.0.tgz",
-      "integrity": "sha512-YDVSAgjkeJ0PvxXDJVN9MZDX7oYRzidLtGHmGgRGd6gSk/bF2ygAKvND4FI1YxDc/cRLQjqAFCpCYaC/9wqIEA==",
-      "license": "MIT"
+      "resolved": "../paperclip/packages/adapter-utils",
+      "link": true
     },
     "node_modules/@types/node": {
       "version": "22.19.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company",
   "type": "module",
   "license": "MIT",
@@ -31,10 +31,12 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "node --test test/*.test.mjs",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@paperclipai/adapter-utils": "^2026.325.0",
+    "@paperclipai/adapter-utils": "file:../paperclip/packages/adapter-utils",
     "picocolors": "^1.1.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,16 @@
  */
 
 import { ADAPTER_TYPE, ADAPTER_LABEL } from "./shared/constants.js";
+import {
+  execute,
+  sessionCodec,
+  testEnvironment,
+  listSkills,
+  syncSkills,
+  getConfigSchema,
+  getQuotaWindows,
+} from "./server/index.js";
+import { detectModel } from "./server/detect-model.js";
 
 export const type = ADAPTER_TYPE;
 export const label = ADAPTER_LABEL;
@@ -22,6 +32,40 @@ export const label = ADAPTER_LABEL;
  * since Hermes availability depends on the user's local configuration.
  */
 export const models: { id: string; label: string }[] = [];
+
+/**
+ * Enable Paperclip to mint a per-run JWT for this adapter.
+ * The JWT is passed as ctx.authToken and injected as PAPERCLIP_API_KEY.
+ */
+export const supportsLocalAgentJwt = true;
+
+// Re-export server functions for direct import convenience
+export { execute, sessionCodec, listSkills, syncSkills, testEnvironment, detectModel, getConfigSchema, getQuotaWindows };
+
+/**
+ * Factory function for the Paperclip external adapter plugin loader.
+ *
+ * plugin-loader.ts calls createServerAdapter() and expects a complete
+ * ServerAdapterModule. This lets the hermes adapter work both as a
+ * builtin (registry.ts picks individual exports) and as an installable
+ * npm plugin.
+ */
+export function createServerAdapter() {
+  return {
+    type: ADAPTER_TYPE,
+    execute,
+    testEnvironment,
+    sessionCodec,
+    listSkills,
+    syncSkills,
+    models,
+    supportsLocalAgentJwt: true,
+    agentConfigurationDoc,
+    detectModel: () => detectModel(),
+    getConfigSchema,
+    getQuotaWindows,
+  };
+}
 
 /**
  * Documentation shown in the Paperclip UI when configuring a Hermes agent.
@@ -42,7 +86,7 @@ tools, persistent memory, session persistence, skills, and MCP support.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | model | string | (Hermes configured default) | Optional explicit model in provider/model format. Leave blank to use Hermes's configured default model. |
-| provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, zai, kimi-coding, minimax, minimax-cn. Usually not needed — Hermes auto-detects from model name. |
+| provider | string | (auto) | Inference provider override (e.g. anthropic, openrouter, nous). If not set, auto-detected from ~/.hermes/config.yaml or inferred from model name. |
 | timeoutSec | number | 300 | Execution timeout in seconds |
 | graceSec | number | 10 | Grace period after SIGTERM before SIGKILL |
 
@@ -50,7 +94,7 @@ tools, persistent memory, session persistence, skills, and MCP support.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| toolsets | string | (all) | Comma-separated toolsets to enable (e.g. "terminal,file,web") |
+| toolsets | string | (all) | Comma-separated Hermes toolsets to enable (e.g. "terminal,file,web,browser,mcp"). If not set, Hermes uses its default toolset configuration. |
 
 ## Session & Workspace
 
@@ -67,8 +111,10 @@ tools, persistent memory, session persistence, skills, and MCP support.
 | hermesCommand | string | hermes | Path to hermes CLI binary |
 | verbose | boolean | false | Enable verbose output |
 | extraArgs | string[] | [] | Additional CLI arguments |
-| env | object | {} | Extra environment variables |
+| env | object | {} | Environment variables passed to the Hermes process. Supports plain strings and \`{ type: "secret_ref", secretId: "..." }\` format for secrets managed by Paperclip. |
+| instructionsFilePath | string | (none) | Path to the agent's AGENTS.md instructions file. Managed by the Paperclip Instructions tab. Content is prepended to the prompt on every heartbeat. |
 | promptTemplate | string | (default) | Custom prompt template with {{variable}} placeholders |
+| bootstrapPromptTemplate | string | (none) | Prompt template used only on the first heartbeat (no session to resume). Omitted on subsequent runs to reduce token waste. Supports the same {{variables}} as promptTemplate. |
 
 ## Available Template Variables
 

--- a/src/server/config-schema.ts
+++ b/src/server/config-schema.ts
@@ -1,0 +1,97 @@
+/**
+ * Declarative config schema for the Hermes Agent adapter.
+ *
+ * Returns a schema so the Paperclip UI can render Hermes-specific
+ * form fields (provider, profile, toolsets) dynamically.
+ */
+
+import type { AdapterConfigSchema, ConfigFieldOption } from "@paperclipai/adapter-utils";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { VALID_PROVIDERS } from "../shared/constants.js";
+import { detectModel } from "./detect-model.js";
+
+const PROVIDER_LABELS: Record<string, string> = {
+  auto: "Auto-detect",
+  anthropic: "Anthropic",
+  openrouter: "OpenRouter",
+  "openai-codex": "OpenAI (Codex)",
+  copilot: "GitHub Copilot",
+  "copilot-acp": "Copilot ACP",
+  nous: "Nous Research",
+  huggingface: "HuggingFace",
+  zai: "Z.AI (GLM)",
+  "kimi-coding": "Kimi Coding",
+  minimax: "MiniMax",
+  "minimax-cn": "MiniMax (CN)",
+  kilocode: "Kilocode",
+};
+
+async function scanProfiles(): Promise<ConfigFieldOption[]> {
+  const options: ConfigFieldOption[] = [
+    { label: "Default (no profile)", value: "" },
+  ];
+  try {
+    const profilesDir = join(homedir(), ".hermes", "profiles");
+    const entries = await readdir(profilesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        options.push({ label: entry.name, value: entry.name });
+      }
+    }
+  } catch {
+    // No profiles directory — only show default option
+  }
+  return options;
+}
+
+export async function getConfigSchema(): Promise<AdapterConfigSchema> {
+  const providerOptions: ConfigFieldOption[] = VALID_PROVIDERS.map((p) => ({
+    label: PROVIDER_LABELS[p] || p,
+    value: p,
+  }));
+
+  let detectedHint = "";
+  try {
+    const detected = await detectModel();
+    if (detected) {
+      detectedHint = ` Detected from config: ${detected.model}` +
+        (detected.provider ? ` (${detected.provider})` : "");
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  const profileOptions = await scanProfiles();
+
+  return {
+    fields: [
+      {
+        key: "provider",
+        label: "Inference Provider",
+        type: "combobox",
+        options: providerOptions,
+        default: "auto",
+        hint: `Which LLM provider to use. "Auto-detect" reads from ~/.hermes/config.yaml or infers from model name.${detectedHint}`,
+        required: false,
+      },
+      {
+        key: "profile",
+        label: "Hermes Profile",
+        type: "select",
+        options: profileOptions,
+        default: "",
+        hint: "Each profile has its own config, memory, skills, and session state. Recommended for running multiple agents.",
+        required: false,
+      },
+      {
+        key: "toolsets",
+        label: "Enabled Toolsets",
+        type: "text",
+        hint: "Comma-separated Hermes toolsets (e.g. terminal,file,web,browser,mcp). Leave blank for Hermes defaults.",
+        required: false,
+      },
+    ],
+  };
+}

--- a/src/server/detect-model.ts
+++ b/src/server/detect-model.ts
@@ -12,6 +12,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { MODEL_PREFIX_PROVIDER_HINTS, VALID_PROVIDERS } from "../shared/constants.js";
+import { resolveHermesHomeDir } from "../shared/profile.js";
 
 export interface DetectedModel {
   /** Model name from config (e.g. "gpt-5.4", "anthropic/claude-sonnet-4") */
@@ -28,11 +29,23 @@ export interface DetectedModel {
 
 /**
  * Read the Hermes config file and extract the default model config.
+ *
+ * When adapterConfig is provided, resolves the profile-specific config path
+ * (e.g. ~/.hermes/profiles/sable/config.yaml) before falling back to the
+ * default ~/.hermes/config.yaml.
  */
 export async function detectModel(
   configPath?: string,
+  adapterConfig?: Record<string, unknown>,
 ): Promise<DetectedModel | null> {
-  const filePath = configPath ?? join(homedir(), ".hermes", "config.yaml");
+  let filePath: string;
+  if (configPath) {
+    filePath = configPath;
+  } else if (adapterConfig) {
+    filePath = join(resolveHermesHomeDir(adapterConfig), "config.yaml");
+  } else {
+    filePath = join(homedir(), ".hermes", "config.yaml");
+  }
 
   let content: string;
   try {

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -18,17 +18,26 @@
  *   --source           session source tag for filtering
  */
 
+import fs from "node:fs/promises";
+import path from "node:path";
+
 import type {
   AdapterExecutionContext,
   AdapterExecutionResult,
-  UsageSummary,
 } from "@paperclipai/adapter-utils";
+
+import { parseHermesOutput, isHermesUnknownSessionError, isHermesMaxTurnsResult } from "./parse.js";
 
 import {
   runChildProcess,
   buildPaperclipEnv,
+  buildInvocationEnvForLogs,
+  ensureCommandResolvable,
   renderTemplate,
+  renderPaperclipWakePrompt,
+  stringifyPaperclipWakePayload,
   ensureAbsoluteDirectory,
+  joinPromptSections,
 } from "@paperclipai/adapter-utils/server-utils";
 
 import {
@@ -36,8 +45,8 @@ import {
   DEFAULT_TIMEOUT_SEC,
   DEFAULT_GRACE_SEC,
   DEFAULT_MODEL,
-  VALID_PROVIDERS,
 } from "../shared/constants.js";
+import { resolveHermesHomeDir } from "../shared/profile.js";
 
 import {
   detectModel,
@@ -64,64 +73,14 @@ function cfgStringArray(v: unknown): string[] | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// Wake-up prompt builder
+// Prompt builder
 // ---------------------------------------------------------------------------
 
-const DEFAULT_PROMPT_TEMPLATE = `You are "{{agentName}}", an AI agent employee in a Paperclip-managed company.
-
-IMPORTANT: Use \`terminal\` tool with \`curl\` for ALL Paperclip API calls (web_extract and browser cannot access localhost).
-
-Your Paperclip identity:
-  Agent ID: {{agentId}}
-  Company ID: {{companyId}}
-  API Base: {{paperclipApiUrl}}
-
-{{#taskId}}
-## Assigned Task
-
-Issue ID: {{taskId}}
-Title: {{taskTitle}}
-
-{{taskBody}}
-
-## Workflow
-
-1. Work on the task using your tools
-2. When done, mark the issue as completed:
-   \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}" -H "Content-Type: application/json" -d '{"status":"done"}'\`
-3. Post a completion comment on the issue summarizing what you did:
-   \`curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments" -H "Content-Type: application/json" -d '{"body":"DONE: <your summary here>"}'\`
-4. If this issue has a parent (check the issue body or comments for references like TRA-XX), post a brief notification on the parent issue so the parent owner knows:
-   \`curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments" -H "Content-Type: application/json" -d '{"body":"{{agentName}} completed {{taskId}}. Summary: <brief>"}'\`
-{{/taskId}}
-
-{{#commentId}}
-## Comment on This Issue
-
-Someone commented. Read it:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}" | python3 -m json.tool\`
-
-Address the comment, POST a reply if needed, then continue working.
-{{/commentId}}
-
-{{#noTask}}
-## Heartbeat Wake — Check for Work
-
-1. List ALL open issues assigned to you (todo, backlog, in_progress):
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
-
-2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
-   - Read the issue details: \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
-   - Do the work in the project directory: {{projectName}}
-   - When done, mark complete and post a comment (see Workflow steps 2-4 above)
-
-3. If no issues assigned to you, check for unassigned issues:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
-   If you find a relevant issue, assign it to yourself:
-   \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
-
-4. If truly nothing to do, report briefly what you checked.
-{{/noTask}}`;
+// Match the default prompt template used by all other Paperclip adapters.
+// The heartbeat workflow, curl examples, checkout procedure, and API reference
+// are provided by the `paperclip` skill (injected at runtime via -s flag),
+// NOT hardcoded into the adapter. This avoids divergence between adapters.
+const DEFAULT_PROMPT_TEMPLATE = `You are agent {{agent.id}} ({{agent.name}}). Continue your Paperclip work.`;
 
 function buildPrompt(
   ctx: AdapterExecutionContext,
@@ -129,180 +88,150 @@ function buildPrompt(
 ): string {
   const template = cfgString(config.promptTemplate) || DEFAULT_PROMPT_TEMPLATE;
 
-  const taskId = cfgString(ctx.config?.taskId);
-  const taskTitle = cfgString(ctx.config?.taskTitle) || "";
-  const taskBody = cfgString(ctx.config?.taskBody) || "";
-  const commentId = cfgString(ctx.config?.commentId) || "";
-  const wakeReason = cfgString(ctx.config?.wakeReason) || "";
-  const agentName = ctx.agent?.name || "Hermes Agent";
-  const companyName = cfgString(ctx.config?.companyName) || "";
-  const projectName = cfgString(ctx.config?.projectName) || "";
-
-  // Build API URL — ensure it has the /api path
-  let paperclipApiUrl =
-    cfgString(config.paperclipApiUrl) ||
-    process.env.PAPERCLIP_API_URL ||
-    "http://127.0.0.1:3100/api";
-  // Ensure /api suffix
-  if (!paperclipApiUrl.endsWith("/api")) {
-    paperclipApiUrl = paperclipApiUrl.replace(/\/+$/, "") + "/api";
-  }
-
-  const vars: Record<string, unknown> = {
+  const templateData: Record<string, unknown> = {
     agentId: ctx.agent?.id || "",
-    agentName,
+    agentName: ctx.agent?.name || "Hermes Agent",
     companyId: ctx.agent?.companyId || "",
-    companyName,
     runId: ctx.runId || "",
-    taskId: taskId || "",
-    taskTitle,
-    taskBody,
-    commentId,
-    wakeReason,
-    projectName,
-    paperclipApiUrl,
+    agent: ctx.agent || {},
+    context: ctx.context || {},
   };
 
-  // Handle conditional sections: {{#key}}...{{/key}}
-  let rendered = template;
-
-  // {{#taskId}}...{{/taskId}} — include if task is assigned
-  rendered = rendered.replace(
-    /\{\{#taskId\}\}([\s\S]*?)\{\{\/taskId\}\}/g,
-    taskId ? "$1" : "",
-  );
-
-  // {{#noTask}}...{{/noTask}} — include if no task
-  rendered = rendered.replace(
-    /\{\{#noTask\}\}([\s\S]*?)\{\{\/noTask\}\}/g,
-    taskId ? "" : "$1",
-  );
-
-  // {{#commentId}}...{{/commentId}} — include if comment exists
-  rendered = rendered.replace(
-    /\{\{#commentId\}\}([\s\S]*?)\{\{\/commentId\}\}/g,
-    commentId ? "$1" : "",
-  );
-
-  // Replace remaining {{variable}} placeholders
-  return renderTemplate(rendered, vars);
+  return renderTemplate(template, templateData);
 }
 
 // ---------------------------------------------------------------------------
-// Output parsing
+// Instructions file loading
 // ---------------------------------------------------------------------------
 
-/** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
-const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
+/**
+ * Read agent instructions from the managed AGENTS.md file and prepend
+ * them to the prompt. This mirrors claude-local's --append-system-prompt-file
+ * behavior but injects directly into the prompt since Hermes has no
+ * equivalent CLI flag.
+ */
+async function loadInstructionsContent(
+  config: Record<string, unknown>,
+): Promise<string | null> {
+  const filePath = cfgString(config.instructionsFilePath);
+  if (!filePath) return null;
 
-/** Regex for legacy session output format */
-const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
-
-/** Regex to extract token usage from Hermes output. */
-const TOKEN_USAGE_REGEX =
-  /tokens?[:\s]+(\d+)\s*(?:input|in)\b.*?(\d+)\s*(?:output|out)\b/i;
-
-/** Regex to extract cost from Hermes output. */
-const COST_REGEX = /(?:cost|spent)[:\s]*\$?([\d.]+)/i;
-
-interface ParsedOutput {
-  sessionId?: string;
-  response?: string;
-  usage?: UsageSummary;
-  costUsd?: number;
-  errorMessage?: string;
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    if (!content.trim()) return null;
+    const dir = path.dirname(filePath) + "/";
+    return (
+      content.trimEnd() +
+      `\n\nThe above agent instructions were loaded from ${filePath}. ` +
+      `Resolve any relative file references from ${dir}.`
+    );
+  } catch {
+    // File not found or not readable — non-fatal
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
-// Response cleaning
+// Billing helper
 // ---------------------------------------------------------------------------
 
-/** Strip noise lines from a Hermes response (tool output, system messages, etc.) */
-function cleanResponse(raw: string): string {
-  return raw
-    .split("\n")
-    .filter((line) => {
-      const t = line.trim();
-      if (!t) return true; // keep blank lines for paragraph separation
-      if (t.startsWith("[tool]") || t.startsWith("[hermes]") || t.startsWith("[paperclip]")) return false;
-      if (t.startsWith("session_id:")) return false;
-      if (/^\[\d{4}-\d{2}-\d{2}T/.test(t)) return false;
-      if (/^\[done\]\s*┊/.test(t)) return false;
-      if (/^┊\s*[\p{Emoji_Presentation}]/u.test(t) && !/^┊\s*💬/.test(t)) return false;
-      if (/^\p{Emoji_Presentation}\s*(Completed|Running|Error)?\s*$/u.test(t)) return false;
-      return true;
-    })
-    .map((line) => {
-      let t = line.replace(/^[\s]*┊\s*💬\s*/, "").trim();
-      t = t.replace(/^\[done\]\s*/, "").trim();
-      return t;
-    })
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+function hasNonEmptyEnvValue(env: Record<string, unknown>, key: string): boolean {
+  const val = env[key];
+  return typeof val === "string" && val.length > 0;
+}
+
+/**
+ * Resolve billing info based on the provider and available API keys.
+ *
+ * - Anthropic without ANTHROPIC_API_KEY → subscription (Claude Pro/Team login)
+ * - Copilot/Copilot-ACP without OPENAI_API_KEY → subscription
+ * - All other providers → api (direct API billing)
+ *
+ * Mirrors the pattern used by claude-local and codex-local adapters.
+ */
+export function resolveHermesBilling(
+  provider: string,
+  env: Record<string, unknown>,
+): { biller: string; billingType: "api" | "subscription" } {
+  const billerMap: Record<string, string> = {
+    anthropic: "anthropic",
+    openrouter: "openrouter",
+    "openai-codex": "openai",
+    copilot: "openai",
+    "copilot-acp": "openai",
+    nous: "nous",
+    zai: "zai",
+    "kimi-coding": "kimi",
+    minimax: "minimax",
+    "minimax-cn": "minimax",
+    huggingface: "huggingface",
+  };
+
+  const biller = billerMap[provider] || provider || "unknown";
+
+  // Detect subscription mode for providers that support it
+  if (provider === "anthropic" && !hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY")) {
+    return { biller, billingType: "subscription" };
+  }
+  if (
+    (provider === "copilot" || provider === "copilot-acp") &&
+    !hasNonEmptyEnvValue(env, "OPENAI_API_KEY")
+  ) {
+    return { biller, billingType: "subscription" };
+  }
+
+  return { biller, billingType: "api" };
 }
 
 // ---------------------------------------------------------------------------
-// Output parsing
+// Cost/usage from Hermes state.db
 // ---------------------------------------------------------------------------
 
-function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
-  const combined = stdout + "\n" + stderr;
-  const result: ParsedOutput = {};
+interface SessionDbData {
+  costUsd: number;
+  inputTokens: number | null;
+  outputTokens: number | null;
+}
 
-  // In quiet mode, Hermes outputs:
-  //   <response text>
-  //
-  //   session_id: <id>
-  const sessionMatch = stdout.match(SESSION_ID_REGEX);
-  if (sessionMatch?.[1]) {
-    result.sessionId = sessionMatch?.[1] ?? null;
-    // The response is everything before the session_id line
-    const sessionLineIdx = stdout.lastIndexOf("\nsession_id:");
-    if (sessionLineIdx > 0) {
-      result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
+/**
+ * Read cost and token usage from Hermes's SQLite database.
+ *
+ * Hermes stores `estimated_cost_usd`, `input_tokens`, and `output_tokens`
+ * in the `sessions` table of `state.db`. This is the source of truth for
+ * cost — stdout regex is unreliable in quiet mode.
+ *
+ * Requires Node.js 22+ (node:sqlite). Non-fatal on failure.
+ */
+export async function getSessionDataFromDb(
+  sessionId: string,
+  dbPath: string,
+): Promise<SessionDbData | null> {
+  try {
+    // Dynamic import to avoid hard failure on Node < 22
+    const { DatabaseSync } = await import("node:sqlite");
+    const db = new DatabaseSync(dbPath, { open: true });
+    try {
+      const stmt = db.prepare(
+        "SELECT estimated_cost_usd, input_tokens, output_tokens FROM sessions WHERE id = ?",
+      );
+      const row = stmt.get(sessionId) as {
+        estimated_cost_usd: number | null;
+        input_tokens: number | null;
+        output_tokens: number | null;
+      } | undefined;
+      if (!row || row.estimated_cost_usd == null) return null;
+      return {
+        costUsd: row.estimated_cost_usd,
+        inputTokens: row.input_tokens ?? null,
+        outputTokens: row.output_tokens ?? null,
+      };
+    } finally {
+      db.close();
     }
-  } else {
-    // Legacy format (non-quiet mode)
-    const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
-    if (legacyMatch?.[1]) {
-      result.sessionId = legacyMatch?.[1] ?? null;
-    }
-    // In non-quiet mode, extract clean response from stdout by
-    // filtering out tool lines, system messages, and noise
-    const cleaned = cleanResponse(stdout);
-    if (cleaned.length > 0) {
-      result.response = cleaned;
-    }
+  } catch {
+    // Non-fatal: database missing, table missing, Node < 22, etc.
+    return null;
   }
-
-  // Extract token usage
-  const usageMatch = combined.match(TOKEN_USAGE_REGEX);
-  if (usageMatch) {
-    result.usage = {
-      inputTokens: parseInt(usageMatch[1], 10) || 0,
-      outputTokens: parseInt(usageMatch[2], 10) || 0,
-    };
-  }
-
-  // Extract cost
-  const costMatch = combined.match(COST_REGEX);
-  if (costMatch?.[1]) {
-    result.costUsd = parseFloat(costMatch[1]);
-  }
-
-  // Check for error patterns in stderr
-  if (stderr.trim()) {
-    const errorLines = stderr
-      .split("\n")
-      .filter((line) => /error|exception|traceback|failed/i.test(line))
-      .filter((line) => !/INFO|DEBUG|warn/i.test(line)); // skip log-level noise
-    if (errorLines.length > 0) {
-      result.errorMessage = errorLines.slice(0, 5).join("\n");
-    }
-  }
-
-  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -313,9 +242,13 @@ export async function execute(
   ctx: AdapterExecutionContext,
 ): Promise<AdapterExecutionResult> {
   const config = (ctx.config ?? ctx.agent?.adapterConfig ?? {}) as Record<string, unknown>;
+  const context = (ctx.context ?? {}) as Record<string, unknown>;
 
   // ── Resolve configuration ──────────────────────────────────────────────
-  const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
+  const hermesCmd =
+    cfgString(config.hermesCommand) ||
+    cfgString(config.command) || // UI writes "command", not "hermesCommand"
+    HERMES_CLI;
   const model = cfgString(config.model) || DEFAULT_MODEL;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
@@ -327,21 +260,12 @@ export async function execute(
   const checkpoints = cfgBoolean(config.checkpoints) === true;
 
   // ── Resolve provider (defense in depth) ────────────────────────────────
-  // Priority chain:
-  //   1. Explicit provider in adapterConfig (user override)
-  //   2. Provider from ~/.hermes/config.yaml (detected at runtime)
-  //   3. Provider inferred from model name prefix
-  //   4. "auto" (let Hermes decide)
-  //
-  // This ensures that even if the agent was created before provider tracking
-  // was added, or if the model was changed without updating provider, the
-  // correct provider is still used.
   let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
   const explicitProvider = cfgString(config.provider);
 
   if (!explicitProvider) {
     try {
-      detectedConfig = await detectModel();
+      detectedConfig = await detectModel(undefined, config);
     } catch {
       // Non-fatal — detection failure shouldn't block execution
     }
@@ -355,7 +279,67 @@ export async function execute(
   });
 
   // ── Build prompt ───────────────────────────────────────────────────────
-  const prompt = buildPrompt(ctx, config);
+  // Compose the prompt from multiple sections, similar to claude-local:
+  //   1. Agent instructions (AGENTS.md from Instructions tab)
+  //   2. Wake prompt (structured Paperclip wake payload, if available)
+  //   3. Heartbeat prompt (the main template with task/comment/heartbeat sections)
+
+  // Hoist prevSessionId so it's available for both prompt building and args
+  const prevSessionId = cfgString(
+    (ctx.runtime?.sessionParams as Record<string, unknown> | null)?.sessionId,
+  );
+
+  const instructionsContent = await loadInstructionsContent(config);
+
+  // Use Paperclip's structured wake prompt renderer if a wake payload exists
+  // and the function is available in this version of adapter-utils
+  let wakePrompt: string | null = null;
+  if (context.paperclipWake) {
+    try {
+      wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, {
+        resumedSession: Boolean(prevSessionId),
+      });
+    } catch {
+      // Non-fatal — fall back to template-only prompt
+    }
+  }
+
+  // Session handoff markdown (set by server when rotating sessions)
+  const sessionHandoffMarkdown = cfgString(context.paperclipSessionHandoffMarkdown);
+
+  const heartbeatPrompt = buildPrompt(ctx, config);
+
+  let bootstrapPrompt: string | null = null;
+  const bootstrapTemplate = cfgString(config.bootstrapPromptTemplate);
+  if (bootstrapTemplate && !(persistSession && prevSessionId)) {
+    const templateData: Record<string, unknown> = {
+      agentId: ctx.agent?.id || "",
+      agentName: ctx.agent?.name || "Hermes Agent",
+      companyId: ctx.agent?.companyId || "",
+      runId: ctx.runId || "",
+      agent: ctx.agent || {},
+      context: ctx.context || {},
+    };
+    bootstrapPrompt = renderTemplate(bootstrapTemplate, templateData);
+  }
+
+  const prompt = joinPromptSections([
+    instructionsContent,
+    bootstrapPrompt,
+    wakePrompt,
+    sessionHandoffMarkdown,
+    heartbeatPrompt,
+  ]);
+
+  // Track prompt section sizes for observability (matches claude-local/codex-local)
+  const promptMetrics: Record<string, number> = {
+    promptChars: prompt.length,
+    heartbeatPromptChars: heartbeatPrompt.length,
+  };
+  if (instructionsContent) promptMetrics.instructionsChars = instructionsContent.length;
+  if (bootstrapPrompt) promptMetrics.bootstrapPromptChars = bootstrapPrompt.length;
+  if (wakePrompt) promptMetrics.wakePromptChars = wakePrompt.length;
+  if (sessionHandoffMarkdown) promptMetrics.sessionHandoffChars = sessionHandoffMarkdown.length;
 
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line
@@ -368,7 +352,6 @@ export async function execute(
   }
 
   // Always pass --provider when we have a resolved one (not "auto").
-  // "auto" means Hermes will decide on its own — no need to pass it.
   if (resolvedProvider !== "auto") {
     args.push("--provider", resolvedProvider);
   }
@@ -386,26 +369,85 @@ export async function execute(
   if (cfgBoolean(config.verbose) === true) args.push("-v");
 
   // Tag sessions as "tool" source so they don't clutter the user's session history.
-  // Requires hermes-agent >= PR #3255 (feat/session-source-tag).
   args.push("--source", "tool");
 
   // Bypass Hermes dangerous-command approval prompts.
-  // Paperclip agents run as non-interactive subprocesses with no TTY,
-  // so approval prompts would always timeout and deny legitimate commands
-  // (curl, python3 -c, etc.). Agents operate in a sandbox — the approval
-  // system is designed for human-attended interactive sessions.
+  // Paperclip agents run as non-interactive subprocesses with no TTY.
   args.push("--yolo");
 
-  // Session resume
-  const prevSessionId = cfgString(
-    (ctx.runtime?.sessionParams as Record<string, unknown> | null)?.sessionId,
+  // Session resume — read params now, validate CWD after cwd is resolved below
+  // (prevSessionId was hoisted above for use in prompt building)
+  const prevSessionCwd = cfgString(
+    (ctx.runtime?.sessionParams as Record<string, unknown> | null)?.cwd,
   );
-  if (persistSession && prevSessionId) {
-    args.push("--resume", prevSessionId);
-  }
 
   if (extraArgs?.length) {
     args.push(...extraArgs);
+  }
+
+  // ── Inject Paperclip skills ────────────────────────────────────────────
+  // The Paperclip server populates config.paperclipRuntimeSkills with
+  // materialized skill entries (source paths on disk). We create real
+  // directories inside ~/.hermes/skills/paperclip/<name>/ and symlink
+  // the individual files (SKILL.md, references/, etc.) into them.
+  //
+  // Why not symlink the directory itself? Python's pathlib.rglob() does
+  // not follow directory symlinks, so Hermes's skill scanner would miss
+  // them entirely. By creating a real directory with symlinked contents,
+  // rglob traverses into it and finds SKILL.md.
+  //
+  // Then pass each skill name via the -s flag so Hermes preloads them
+  // into the agent's system prompt for the session.
+  const runtimeSkills = config.paperclipRuntimeSkills;
+  if (Array.isArray(runtimeSkills) && runtimeSkills.length > 0) {
+    try {
+      const hermesHome = resolveHermesHomeDir(config);
+      const paperclipSkillsDir = path.join(hermesHome, "skills", "paperclip");
+      await fs.mkdir(paperclipSkillsDir, { recursive: true });
+      const injectedSkillNames: string[] = [];
+
+      for (const entry of runtimeSkills) {
+        const e = entry as Record<string, unknown>;
+        const name = cfgString(e.runtimeName) || cfgString(e.key);
+        const source = cfgString(e.source);
+        if (!name || !source) continue;
+
+        const targetDir = path.join(paperclipSkillsDir, name);
+        try {
+          // Create a real directory (not a symlink) so rglob traverses it
+          await fs.mkdir(targetDir, { recursive: true });
+
+          // Symlink each file/subdir from the source into the target dir
+          const sourceEntries = await fs.readdir(source, { withFileTypes: true });
+          for (const srcEntry of sourceEntries) {
+            const srcPath = path.join(source, srcEntry.name);
+            const dstPath = path.join(targetDir, srcEntry.name);
+
+            // Check if symlink already correct
+            const existingTarget = await fs.readlink(dstPath).catch(() => null);
+            if (existingTarget === srcPath) continue;
+
+            // Remove stale entry
+            if (existingTarget !== null || await fs.stat(dstPath).catch(() => null)) {
+              await fs.rm(dstPath, { recursive: true, force: true });
+            }
+
+            await fs.symlink(srcPath, dstPath);
+          }
+
+          injectedSkillNames.push(name);
+        } catch {
+          // Non-fatal — skip this skill
+        }
+      }
+
+      if (injectedSkillNames.length > 0) {
+        // Use category/name format since skills are in paperclip/ subdir
+        args.push("-s", injectedSkillNames.map((n) => `paperclip/${n}`).join(","));
+      }
+    } catch {
+      // Non-fatal — skills injection failed, agent runs without Paperclip skills
+    }
   }
 
   // ── Build environment ──────────────────────────────────────────────────
@@ -415,23 +457,147 @@ export async function execute(
   };
 
   if (ctx.runId) env.PAPERCLIP_RUN_ID = ctx.runId;
-  if ((ctx as any).authToken && !env.PAPERCLIP_API_KEY)
-    env.PAPERCLIP_API_KEY = (ctx as any).authToken;
-  const taskId = cfgString(ctx.config?.taskId);
-  if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
-  const userEnv = config.env as Record<string, string> | undefined;
-  if (userEnv && typeof userEnv === "object") {
-    Object.assign(env, userEnv);
+  // Read task/wake context from ctx.context (wake context)
+  const envTaskId =
+    cfgString(context.taskId) ||
+    cfgString(context.issueId) ||
+    cfgString(ctx.config?.taskId);
+  if (envTaskId) env.PAPERCLIP_TASK_ID = envTaskId;
+
+  const envWakeReason =
+    cfgString(context.wakeReason) || cfgString(ctx.config?.wakeReason);
+  if (envWakeReason) env.PAPERCLIP_WAKE_REASON = envWakeReason;
+
+  const envCommentId =
+    cfgString(context.commentId) ||
+    cfgString(context.wakeCommentId) ||
+    cfgString(ctx.config?.commentId);
+  if (envCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = envCommentId;
+
+  const approvalId = cfgString(context.approvalId);
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  const approvalStatus = cfgString(context.approvalStatus);
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+
+  // Workspace context — pass through so agent scripts can use them
+  const workspace = context.paperclipWorkspace as Record<string, unknown> | undefined;
+  if (workspace) {
+    if (cfgString(workspace.cwd)) env.PAPERCLIP_WORKSPACE_CWD = workspace.cwd as string;
+    if (cfgString(workspace.source)) env.PAPERCLIP_WORKSPACE_SOURCE = workspace.source as string;
+    if (cfgString(workspace.strategy)) env.PAPERCLIP_WORKSPACE_STRATEGY = workspace.strategy as string;
+    if (cfgString(workspace.workspaceId)) env.PAPERCLIP_WORKSPACE_ID = workspace.workspaceId as string;
+    if (cfgString(workspace.repoUrl)) env.PAPERCLIP_WORKSPACE_REPO_URL = workspace.repoUrl as string;
+    if (cfgString(workspace.repoRef)) env.PAPERCLIP_WORKSPACE_REPO_REF = workspace.repoRef as string;
+    if (cfgString(workspace.branchName)) env.PAPERCLIP_WORKSPACE_BRANCH = workspace.branchName as string;
+    if (cfgString(workspace.worktreePath)) env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = workspace.worktreePath as string;
+    if (cfgString(workspace.agentHome)) env.AGENT_HOME = workspace.agentHome as string;
+  }
+
+  // Linked issues
+  const issueIds = context.issueIds;
+  if (Array.isArray(issueIds) && issueIds.length > 0) {
+    env.PAPERCLIP_LINKED_ISSUE_IDS = issueIds.join(",");
+  }
+
+  // Wake payload JSON for agents that want structured context
+  if (context.paperclipWake) {
+    try {
+      const payload = stringifyPaperclipWakePayload(context.paperclipWake);
+      if (payload) env.PAPERCLIP_WAKE_PAYLOAD_JSON = payload;
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  // Runtime service env vars
+  const workspaces = context.paperclipWorkspaces;
+  if (Array.isArray(workspaces) && workspaces.length > 0) {
+    try { env.PAPERCLIP_WORKSPACES_JSON = JSON.stringify(workspaces); } catch {}
+  }
+  const serviceIntents = context.paperclipRuntimeServiceIntents;
+  if (Array.isArray(serviceIntents) && serviceIntents.length > 0) {
+    try { env.PAPERCLIP_RUNTIME_SERVICE_INTENTS_JSON = JSON.stringify(serviceIntents); } catch {}
+  }
+  const services = context.paperclipRuntimeServices;
+  if (Array.isArray(services) && services.length > 0) {
+    try { env.PAPERCLIP_RUNTIME_SERVICES_JSON = JSON.stringify(services); } catch {}
+  }
+  const primaryUrl = cfgString(context.paperclipRuntimePrimaryUrl);
+  if (primaryUrl) env.PAPERCLIP_RUNTIME_PRIMARY_URL = primaryUrl;
+
+  // User-configured env vars (already resolved by the server — plain strings)
+  const userEnv = config.env;
+  if (userEnv && typeof userEnv === "object" && !Array.isArray(userEnv)) {
+    for (const [key, val] of Object.entries(userEnv as Record<string, unknown>)) {
+      if (typeof val === "string") {
+        env[key] = val;
+      } else if (val && typeof val === "object" && "value" in val && typeof (val as any).value === "string") {
+        // Handle legacy wrapped format: { type: "plain", value: "..." }
+        env[key] = (val as any).value;
+      }
+    }
+  }
+
+  // Inject authToken as PAPERCLIP_API_KEY so Hermes can authenticate
+  // to the Paperclip API. ctx.authToken is a first-class field on
+  // AdapterExecutionContext — no cast needed.
+  // Only set if userEnv didn't already provide an explicit PAPERCLIP_API_KEY.
+  const hasExplicitApiKey = typeof env.PAPERCLIP_API_KEY === "string" && env.PAPERCLIP_API_KEY.length > 0;
+  if (ctx.authToken && !hasExplicitApiKey) {
+    env.PAPERCLIP_API_KEY = ctx.authToken;
   }
 
   // ── Resolve working directory ──────────────────────────────────────────
-  const cwd =
-    cfgString(config.cwd) || cfgString(ctx.config?.workspaceDir) || ".";
+  // Prefer workspace CWD from context (set by Paperclip's workspace
+  // resolver), fall back to adapter config, then process cwd.
+  let cwd: string;
+  if (workspace && cfgString(workspace.cwd) && cfgString(workspace.source) !== "agent_home") {
+    cwd = workspace.cwd as string;
+  } else {
+    cwd = cfgString(config.cwd) || cfgString(ctx.config?.workspaceDir) || ".";
+  }
   try {
-    await ensureAbsoluteDirectory(cwd);
+    await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
   } catch {
     // Non-fatal
+  }
+
+  // ── Session resume (CWD-validated) ────────────────────────────────────
+  let sessionId: string | null = (persistSession && prevSessionId) ? prevSessionId : null;
+  if (sessionId && prevSessionCwd && prevSessionCwd !== cwd) {
+    await ctx.onLog(
+      "stdout",
+      `[hermes] CWD mismatch: session was started in ${prevSessionCwd}, current cwd is ${cwd}. Dropping session resume.\n`,
+    );
+    sessionId = null;
+  }
+  if (sessionId) {
+    args.push("--resume", sessionId);
+  }
+
+  // ── Emit invocation metadata ───────────────────────────────────────────
+  // Report execution metadata so Paperclip can display it in the run
+  // detail view (command, args, env, prompt).
+  if (ctx.onMeta) {
+    try {
+      const loggedEnv = buildInvocationEnvForLogs(env);
+      await ctx.onMeta({
+        adapterType: "hermes_local",
+        command: hermesCmd,
+        cwd,
+        commandArgs: args,
+        commandNotes: instructionsContent
+          ? [`Injected agent instructions from ${cfgString(config.instructionsFilePath)}`]
+          : undefined,
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    } catch {
+      // Non-fatal — metadata reporting should never block execution
+    }
   }
 
   // ── Log start ──────────────────────────────────────────────────────────
@@ -439,10 +605,16 @@ export async function execute(
     "stdout",
     `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
   );
-  if (prevSessionId) {
+  if (sessionId) {
     await ctx.onLog(
       "stdout",
-      `[hermes] Resuming session: ${prevSessionId}\n`,
+      `[hermes] Resuming session: ${sessionId}\n`,
+    );
+  }
+  if (instructionsContent) {
+    await ctx.onLog(
+      "stdout",
+      `[hermes] Injected agent instructions from ${cfgString(config.instructionsFilePath)}\n`,
     );
   }
 
@@ -450,15 +622,22 @@ export async function execute(
   // Hermes writes non-error noise to stderr (MCP init, INFO logs, etc).
   // Paperclip renders all stderr as red/error in the UI.
   // Wrap onLog to reclassify benign stderr lines as stdout.
+  //
+  // For skill security warnings: Hermes hardcodes ~/.hermes/skills/ as the
+  // trusted directory, but profile skills live in ~/.hermes/profiles/<name>/skills/.
+  // We suppress warnings that reference our own injected skills path (known safe)
+  // while letting warnings about unknown paths through.
+  const hermesHome = resolveHermesHomeDir(config);
+  const ownSkillsPath = path.join(hermesHome, "skills");
   const wrappedOnLog = async (stream: "stdout" | "stderr", chunk: string) => {
     if (stream === "stderr") {
       const trimmed = chunk.trimEnd();
-      // Benign patterns that should NOT appear as errors:
-      // - Structured log lines: [timestamp] INFO/DEBUG/WARN: ...
-      // - MCP server registration messages
-      // - Python import/site noise
-      const isBenign = /^\[?\d{4}[-/]\d{2}[-/]\d{2}T/.test(trimmed) || // structured timestamps
-        /^[A-Z]+:\s+(INFO|DEBUG|WARN|WARNING)\b/.test(trimmed) || // log levels
+      // Reclassify known-safe skill security warnings with [hermes] prefix
+      if (/Skill security warning/.test(trimmed) && trimmed.includes(ownSkillsPath)) {
+        return ctx.onLog("stdout", `[hermes] ${chunk}`);
+      }
+      const isBenign = /^\[?\d{4}[-/]\d{2}[-/]\d{2}T/.test(trimmed) ||
+        /^[A-Z]+:\s+(INFO|DEBUG|WARN|WARNING)\b/.test(trimmed) ||
         /Successfully registered all tools/.test(trimmed) ||
         /MCP [Ss]erver/.test(trimmed) ||
         /tool registered successfully/.test(trimmed) ||
@@ -470,64 +649,154 @@ export async function execute(
     return ctx.onLog(stream, chunk);
   };
 
-  const result = await runChildProcess(ctx.runId, hermesCmd, args, {
-    cwd,
-    env,
-    timeoutSec,
-    graceSec,
-    onLog: wrappedOnLog,
-  });
-
-  // ── Parse output ───────────────────────────────────────────────────────
-  const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");
-
-  await ctx.onLog(
-    "stdout",
-    `[hermes] Exit code: ${result.exitCode ?? "null"}, timed out: ${result.timedOut}\n`,
-  );
-  if (parsed.sessionId) {
-    await ctx.onLog("stdout", `[hermes] Session: ${parsed.sessionId}\n`);
+  // ── Validate command resolvability ────────────────────────────────────
+  try {
+    await ensureCommandResolvable(hermesCmd, cwd, env as NodeJS.ProcessEnv);
+  } catch (err) {
+    // Non-fatal — proceed with original command, let runChildProcess handle errors
+    await ctx.onLog("stderr", `[hermes] Warning: could not verify "${hermesCmd}" is resolvable: ${(err as Error).message}\n`);
   }
 
-  // ── Build result ───────────────────────────────────────────────────────
-  const executionResult: AdapterExecutionResult = {
-    exitCode: result.exitCode,
-    signal: result.signal,
-    timedOut: result.timedOut,
-    provider: resolvedProvider,
-    model,
-  };
+  let clearSessionOnRetry = false;
 
-  if (parsed.errorMessage) {
-    executionResult.errorMessage = parsed.errorMessage;
+  try {
+    let result = await runChildProcess(ctx.runId, hermesCmd, args, {
+      cwd,
+      env,
+      timeoutSec,
+      graceSec,
+      onLog: wrappedOnLog,
+      onSpawn: ctx.onSpawn,
+    });
+
+    // Retry on unknown session error (session ID no longer valid on Hermes side)
+    if (
+      sessionId &&
+      result.exitCode !== 0 &&
+      !result.timedOut &&
+      isHermesUnknownSessionError(result.stdout || "", result.stderr || "")
+    ) {
+      await ctx.onLog(
+        "stdout",
+        `[hermes] Unknown session error detected; retrying without --resume.\n`,
+      );
+      const retryArgs = args.filter((arg, i, arr) =>
+        !(arg === "--resume" || (i > 0 && arr[i - 1] === "--resume" && arg === sessionId)),
+      );
+      result = await runChildProcess(ctx.runId, hermesCmd, retryArgs, {
+        cwd,
+        env,
+        timeoutSec,
+        graceSec,
+        onLog: wrappedOnLog,
+        onSpawn: ctx.onSpawn,
+      });
+      clearSessionOnRetry = true;
+    }
+
+    // ── Parse output ───────────────────────────────────────────────────────
+    const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");
+
+    await ctx.onLog(
+      "stdout",
+      `[hermes] Exit code: ${result.exitCode ?? "null"}, timed out: ${result.timedOut}\n`,
+    );
+    if (parsed.sessionId) {
+      await ctx.onLog("stdout", `[hermes] Session: ${parsed.sessionId}\n`);
+    }
+
+    // ── Enrich cost/usage from state.db ──────────────────────────────────
+    // Hermes quiet mode does not emit cost/usage to stdout. Query state.db
+    // as the authoritative source, falling back to parsed stdout values.
+    if (parsed.sessionId) {
+      try {
+        const hermesHome = resolveHermesHomeDir(config);
+        const stateDbPath = path.join(hermesHome, "state.db");
+        const dbData = await getSessionDataFromDb(parsed.sessionId, stateDbPath);
+        if (dbData) {
+          if (parsed.costUsd === undefined) {
+            parsed.costUsd = dbData.costUsd;
+            await ctx.onLog("stdout", `[hermes] Cost from state.db: $${dbData.costUsd.toFixed(6)}\n`);
+          }
+          if (!parsed.usage && (dbData.inputTokens != null || dbData.outputTokens != null)) {
+            parsed.usage = {
+              inputTokens: dbData.inputTokens ?? 0,
+              outputTokens: dbData.outputTokens ?? 0,
+            };
+          }
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    // ── Build result ───────────────────────────────────────────────────────
+    const executionResult: AdapterExecutionResult = {
+      exitCode: result.exitCode,
+      signal: result.signal,
+      timedOut: result.timedOut,
+      provider: resolvedProvider,
+      model,
+    };
+
+    const billing = resolveHermesBilling(resolvedProvider, env);
+    executionResult.biller = billing.biller;
+    executionResult.billingType = billing.billingType;
+
+    if (result.timedOut) {
+      executionResult.errorMessage = `Timed out after ${timeoutSec}s`;
+      executionResult.errorCode = "timeout";
+    } else if (parsed.errorMessage) {
+      executionResult.errorMessage = parsed.errorMessage;
+    }
+
+    if (parsed.usage) {
+      executionResult.usage = parsed.usage;
+    }
+
+    if (parsed.costUsd !== undefined) {
+      executionResult.costUsd = parsed.costUsd;
+    }
+
+    // Summary from agent response
+    if (parsed.response) {
+      executionResult.summary = parsed.response.slice(0, 2000);
+    }
+
+    // Set resultJson so Paperclip can persist run metadata
+    executionResult.resultJson = {
+      result: parsed.response || "",
+      session_id: parsed.sessionId || null,
+      usage: parsed.usage || null,
+      cost_usd: parsed.costUsd ?? null,
+    };
+
+    // Store session ID and workspace metadata for next run
+    if (persistSession && parsed.sessionId) {
+      const sessionParams: Record<string, string> = {
+        sessionId: parsed.sessionId,
+        cwd,
+      };
+      // Include workspace metadata for execution workspace lifecycle
+      const wsId = workspace ? cfgString(workspace.workspaceId) : undefined;
+      const wsRepoUrl = workspace ? cfgString(workspace.repoUrl) : undefined;
+      const wsRepoRef = workspace ? cfgString(workspace.repoRef) : undefined;
+      if (wsId) sessionParams.workspaceId = wsId;
+      if (wsRepoUrl) sessionParams.repoUrl = wsRepoUrl;
+      if (wsRepoRef) sessionParams.repoRef = wsRepoRef;
+
+      executionResult.sessionParams = sessionParams;
+      executionResult.sessionDisplayId = parsed.sessionId;
+    }
+
+    // Signal Paperclip to clear the persisted session when needed
+    if (clearSessionOnRetry || isHermesMaxTurnsResult(result.stdout || "", result.stderr || "")) {
+      executionResult.clearSession = true;
+    }
+
+    return executionResult;
+  } finally {
+    // Skills are persistently symlinked into ~/.hermes/skills/paperclip/
+    // and reused across runs — no temp directory cleanup needed.
   }
-
-  if (parsed.usage) {
-    executionResult.usage = parsed.usage;
-  }
-
-  if (parsed.costUsd !== undefined) {
-    executionResult.costUsd = parsed.costUsd;
-  }
-
-  // Summary from agent response
-  if (parsed.response) {
-    executionResult.summary = parsed.response.slice(0, 2000);
-  }
-
-  // Set resultJson so Paperclip can persist run metadata (used for UI display + auto-comments)
-  executionResult.resultJson = {
-    result: parsed.response || "",
-    session_id: parsed.sessionId || null,
-    usage: parsed.usage || null,
-    cost_usd: parsed.costUsd ?? null,
-  };
-
-  // Store session ID for next run
-  if (persistSession && parsed.sessionId) {
-    executionResult.sessionParams = { sessionId: parsed.sessionId };
-    executionResult.sessionDisplayId = parsed.sessionId.slice(0, 16);
-  }
-
-  return executionResult;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { execute } from "./execute.js";
+export { parseHermesOutput, isHermesUnknownSessionError, isHermesMaxTurnsResult, cleanResponse } from "./parse.js";
 export { testEnvironment } from "./test.js";
 export { detectModel, parseModelFromConfig, resolveProvider, inferProviderFromModel } from "./detect-model.js";
 export {
@@ -10,6 +11,8 @@ export {
   syncHermesSkills as syncSkills,
   resolveHermesDesiredSkillNames as resolveDesiredSkillNames,
 } from "./skills.js";
+export { getConfigSchema } from "./config-schema.js";
+export { getQuotaWindows } from "./quota.js";
 
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
 
@@ -31,15 +34,31 @@ export const sessionCodec: AdapterSessionCodec = {
       readNonEmptyString(record.sessionId) ??
       readNonEmptyString(record.session_id);
     if (!sessionId) return null;
-    return { sessionId };
+    const result: Record<string, string> = { sessionId };
+    const cwd = readNonEmptyString(record.cwd) ?? readNonEmptyString(record.workdir);
+    if (cwd) result.cwd = cwd;
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    if (workspaceId) result.workspaceId = workspaceId;
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    if (repoUrl) result.repoUrl = repoUrl;
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    if (repoRef) result.repoRef = repoRef;
+    return result;
   },
   serialize(params: Record<string, unknown> | null) {
     if (!params) return null;
-    const sessionId =
-      readNonEmptyString(params.sessionId) ??
-      readNonEmptyString(params.session_id);
+    const sessionId = readNonEmptyString(params.sessionId);
     if (!sessionId) return null;
-    return { sessionId };
+    const result: Record<string, string> = { sessionId };
+    const cwd = readNonEmptyString(params.cwd);
+    if (cwd) result.cwd = cwd;
+    const workspaceId = readNonEmptyString(params.workspaceId);
+    if (workspaceId) result.workspaceId = workspaceId;
+    const repoUrl = readNonEmptyString(params.repoUrl);
+    if (repoUrl) result.repoUrl = repoUrl;
+    const repoRef = readNonEmptyString(params.repoRef);
+    if (repoRef) result.repoRef = repoRef;
+    return result;
   },
   getDisplayId(params: Record<string, unknown> | null) {
     if (!params) return null;

--- a/src/server/parse.ts
+++ b/src/server/parse.ts
@@ -1,0 +1,159 @@
+/**
+ * Hermes output parsing utilities.
+ *
+ * Extracted from execute.ts to improve testability and enable session retry
+ * logic (Task 4). All parsing concerns live here; execute.ts imports from
+ * this module.
+ */
+
+import type { UsageSummary } from "@paperclipai/adapter-utils";
+
+// ---------------------------------------------------------------------------
+// Output parsing
+// ---------------------------------------------------------------------------
+
+/** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
+export const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
+
+/** Regex for legacy session output format */
+export const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
+
+/** Regex to extract token usage from Hermes output. */
+export const TOKEN_USAGE_REGEX =
+  /tokens?[:\s]+(\d+)\s*(?:input|in)\b.*?(\d+)\s*(?:output|out)\b/i;
+
+/** Regex to extract cost from Hermes output. */
+export const COST_REGEX = /(?:cost|spent)[:\s]*\$?([\d.]+)/i;
+
+export interface ParsedHermesOutput {
+  sessionId?: string;
+  response?: string;
+  usage?: UsageSummary;
+  costUsd?: number;
+  errorMessage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Response cleaning
+// ---------------------------------------------------------------------------
+
+/** Strip noise lines from a Hermes response (tool output, system messages, etc.) */
+export function cleanResponse(raw: string): string {
+  return raw
+    .split("\n")
+    .filter((line) => {
+      const t = line.trim();
+      if (!t) return true; // keep blank lines for paragraph separation
+      if (t.startsWith("[tool]") || t.startsWith("[hermes]") || t.startsWith("[paperclip]")) return false;
+      if (t.startsWith("session_id:")) return false;
+      if (/^\[\d{4}-\d{2}-\d{2}T/.test(t)) return false;
+      if (/^\[done\]\s*┊/.test(t)) return false;
+      if (/^┊\s*[\p{Emoji_Presentation}]/u.test(t) && !/^┊\s*💬/.test(t)) return false;
+      if (/^\p{Emoji_Presentation}\s*(Completed|Running|Error)?\s*$/u.test(t)) return false;
+      return true;
+    })
+    .map((line) => {
+      let t = line.replace(/^[\s]*┊\s*💬\s*/, "").trim();
+      t = t.replace(/^\[done\]\s*/, "").trim();
+      return t;
+    })
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Output parsing
+// ---------------------------------------------------------------------------
+
+export function parseHermesOutput(stdout: string, stderr: string): ParsedHermesOutput {
+  const combined = stdout + "\n" + stderr;
+  const result: ParsedHermesOutput = {};
+
+  // In quiet mode, Hermes outputs:
+  //   <response text>
+  //
+  //   session_id: <id>
+  const sessionMatch = stdout.match(SESSION_ID_REGEX);
+  if (sessionMatch?.[1]) {
+    result.sessionId = sessionMatch?.[1] ?? null;
+    // The response is everything before the session_id line
+    const sessionLineIdx = stdout.lastIndexOf("\nsession_id:");
+    if (sessionLineIdx > 0) {
+      result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
+    }
+  } else {
+    // Legacy format (non-quiet mode)
+    const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
+    if (legacyMatch?.[1]) {
+      result.sessionId = legacyMatch?.[1] ?? null;
+    }
+    // In non-quiet mode, extract clean response from stdout by
+    // filtering out tool lines, system messages, and noise
+    const cleaned = cleanResponse(stdout);
+    if (cleaned.length > 0) {
+      result.response = cleaned;
+    }
+  }
+
+  // Extract token usage
+  const usageMatch = combined.match(TOKEN_USAGE_REGEX);
+  if (usageMatch) {
+    result.usage = {
+      inputTokens: parseInt(usageMatch[1], 10) || 0,
+      outputTokens: parseInt(usageMatch[2], 10) || 0,
+    };
+  }
+
+  // Extract cost
+  const costMatch = combined.match(COST_REGEX);
+  if (costMatch?.[1]) {
+    result.costUsd = parseFloat(costMatch[1]);
+  }
+
+  // Check for error patterns in stderr
+  if (stderr.trim()) {
+    const errorLines = stderr
+      .split("\n")
+      .filter((line) => /error|exception|traceback|failed/i.test(line))
+      .filter((line) => !/INFO|DEBUG|warn/i.test(line)); // skip log-level noise
+    if (errorLines.length > 0) {
+      result.errorMessage = errorLines.slice(0, 5).join("\n");
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Session error detection
+// ---------------------------------------------------------------------------
+
+/** Regex matching Hermes unknown/invalid session error messages. */
+const UNKNOWN_SESSION_REGEX =
+  /unknown session|session not found|session expired|no conversation found|invalid session/i;
+
+/**
+ * Returns true when Hermes stdout/stderr indicates the resumed session is no
+ * longer valid. Callers can use this signal to retry without `--resume`.
+ */
+export function isHermesUnknownSessionError(stdout: string, stderr: string): boolean {
+  const combined = stdout + "\n" + stderr;
+  return UNKNOWN_SESSION_REGEX.test(combined);
+}
+
+// ---------------------------------------------------------------------------
+// Max-turns detection
+// ---------------------------------------------------------------------------
+
+/** Regex matching Hermes max-turns result messages. */
+const MAX_TURNS_REGEX = /max[_ ]?turns?\s*(?:reached|exceeded|limit)|reached\s+(?:the\s+)?max/i;
+
+/**
+ * Returns true when Hermes stdout/stderr indicates the run stopped because it
+ * hit the configured maximum number of turns.
+ */
+export function isHermesMaxTurnsResult(stdout: string, stderr: string): boolean {
+  const combined = stdout + "\n" + stderr;
+  return MAX_TURNS_REGEX.test(combined);
+}

--- a/src/server/quota.ts
+++ b/src/server/quota.ts
@@ -1,0 +1,19 @@
+/**
+ * Quota windows for the Hermes Agent adapter.
+ *
+ * Hermes supports 13+ providers with no single quota API.
+ * Returns an empty-but-valid result. Future versions can query
+ * provider-specific usage APIs (OpenRouter /api/v1/auth/key,
+ * Anthropic /api/oauth/usage, etc.).
+ */
+
+import type { ProviderQuotaResult } from "@paperclipai/adapter-utils";
+
+export async function getQuotaWindows(): Promise<ProviderQuotaResult> {
+  return {
+    provider: "hermes",
+    ok: true,
+    source: "hermes-adapter",
+    windows: [],
+  };
+}

--- a/src/server/skills.ts
+++ b/src/server/skills.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type {
   AdapterSkillContext,
@@ -11,25 +10,9 @@ import {
   resolvePaperclipDesiredSkillNames,
 } from "@paperclipai/adapter-utils/server-utils";
 import { fileURLToPath } from "node:url";
+import { resolveHermesHomeDir } from "../shared/profile.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function asString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function resolveHermesHome(config: Record<string, unknown>): string {
-  const env =
-    typeof config.env === "object" && config.env !== null && !Array.isArray(config.env)
-      ? (config.env as Record<string, unknown>)
-      : {};
-  const configuredHome = asString(env.HOME);
-  return configuredHome ? path.resolve(configuredHome) : os.homedir();
-}
 
 interface SkillFrontmatter {
   name?: string;
@@ -127,8 +110,8 @@ async function buildSkillEntry(
 // ---------------------------------------------------------------------------
 
 async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promise<AdapterSkillSnapshot> {
-  const home = resolveHermesHome(config);
-  const hermesSkillsHome = path.join(home, ".hermes", "skills");
+  const hermesHome = resolveHermesHomeDir(config);
+  const hermesSkillsHome = path.join(hermesHome, "skills");
 
   // 1. Scan Paperclip-managed skills (bundled with the adapter)
   const paperclipEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
@@ -159,7 +142,7 @@ async function buildHermesSkillSnapshot(config: Record<string, unknown>): Promis
       sourcePath: entry.source,
       targetPath: null,
       detail: desired
-        ? "Will be available on the next run via Hermes skill loading."
+        ? `Will be injected into the Hermes skills directory on the next run.`
         : null,
       required: Boolean(entry.required),
       requiredReason: entry.requiredReason ?? null,

--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -13,6 +13,7 @@ import type {
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import fs from "node:fs";
 
 import { HERMES_CLI, DEFAULT_MODEL, ADAPTER_TYPE, VALID_PROVIDERS } from "../shared/constants.js";
 import { detectModel, resolveProvider, inferProviderFromModel } from "./detect-model.js";
@@ -236,6 +237,99 @@ async function checkProviderConsistency(
   return null;
 }
 
+function checkCwd(
+  config: Record<string, unknown>,
+): AdapterEnvironmentCheck | null {
+  const cwd = asString(config.cwd);
+  if (!cwd) {
+    return {
+      level: "info",
+      message: "No CWD configured — Hermes will use the process working directory",
+      code: "hermes_cwd_default",
+    };
+  }
+  try {
+    const stat = fs.statSync(cwd);
+    if (!stat.isDirectory()) {
+      return {
+        level: "error",
+        message: `Configured CWD "${cwd}" exists but is not a directory`,
+        hint: "Set cwd to a valid directory path in the agent configuration",
+        code: "hermes_cwd_invalid",
+      };
+    }
+    return {
+      level: "info",
+      message: `CWD "${cwd}" exists and is a directory`,
+      code: "hermes_cwd_valid",
+    };
+  } catch {
+    return {
+      level: "error",
+      message: `Configured CWD "${cwd}" does not exist`,
+      hint: "Create the directory or update cwd in the agent configuration",
+      code: "hermes_cwd_invalid",
+    };
+  }
+}
+
+async function checkHelloProbe(
+  command: string,
+  config: Record<string, unknown>,
+): Promise<AdapterEnvironmentCheck> {
+  // Collect any -p/--profile args from extraArgs to pass along
+  const extraArgs = Array.isArray(config.extraArgs)
+    ? (config.extraArgs as unknown[]).filter((a): a is string => typeof a === "string")
+    : [];
+  const profileArgs: string[] = [];
+  for (let i = 0; i < extraArgs.length; i++) {
+    if (extraArgs[i] === "-p" || extraArgs[i] === "--profile") {
+      profileArgs.push(extraArgs[i]);
+      if (i + 1 < extraArgs.length) {
+        profileArgs.push(extraArgs[++i]);
+      }
+    } else if (extraArgs[i].startsWith("--profile=")) {
+      profileArgs.push(extraArgs[i]);
+    }
+  }
+
+  const args = ["chat", "-q", "Respond with hello.", "-Q", ...profileArgs];
+
+  try {
+    const { stdout } = await execFileAsync(command, args, { timeout: 45_000 });
+    const output = stdout.trim().toLowerCase();
+    if (output.includes("hello")) {
+      return {
+        level: "info",
+        message: "Live hello probe passed — Hermes responded correctly",
+        code: "hermes_hello_probe_passed",
+      };
+    }
+    return {
+      level: "warn",
+      message: `Live hello probe returned unexpected output: "${stdout.trim().slice(0, 120)}"`,
+      hint: "Hermes is reachable but the response did not contain 'hello'. Check model and provider configuration.",
+      code: "hermes_hello_probe_unexpected_output",
+    };
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException & { killed?: boolean; signal?: string };
+    if (e.killed || e.signal === "SIGTERM" || (e.message && e.message.includes("timed out"))) {
+      return {
+        level: "warn",
+        message: "Live hello probe timed out after 45 seconds",
+        hint: "Hermes may be slow to respond or the network/API is unreachable",
+        code: "hermes_hello_probe_timed_out",
+      };
+    }
+    return {
+      level: "warn",
+      message: `Live hello probe failed: ${e.message ?? String(err)}`,
+      hint: "Check that Hermes Agent is correctly installed, API keys are set, and the model is accessible",
+      code: "hermes_hello_probe_failed",
+    };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main test
 // ---------------------------------------------------------------------------
@@ -277,9 +371,17 @@ export async function testEnvironment(
   const apiKeyCheck = checkApiKeys(config);
   if (apiKeyCheck) checks.push(apiKeyCheck);
 
-  // 6. Provider/model consistency
+  // 6. CWD validation
+  const cwdCheck = checkCwd(config);
+  if (cwdCheck) checks.push(cwdCheck);
+
+  // 7. Provider/model consistency
   const providerCheck = await checkProviderConsistency(config);
   if (providerCheck) checks.push(providerCheck);
+
+  // 8. Live hello probe
+  const helloProbeCheck = await checkHelloProbe(command, config);
+  checks.push(helloProbeCheck);
 
   // Determine overall status
   const hasErrors = checks.some((c) => c.level === "error");

--- a/src/shared/profile.ts
+++ b/src/shared/profile.ts
@@ -1,0 +1,74 @@
+/**
+ * Profile resolution helpers for the Hermes Agent adapter.
+ *
+ * Hermes supports fully isolated profiles at ~/.hermes/profiles/<name>/,
+ * each with its own config, state, skills, and memory. These helpers
+ * resolve the correct HERMES_HOME directory from adapter config.
+ */
+
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Extract a profile name from adapter config.
+ *
+ * Checks (in priority order):
+ *   1. config.profile (explicit field from getConfigSchema)
+ *   2. -p / --profile in config.extraArgs
+ *
+ * Returns the profile name string, or null if no profile is configured.
+ */
+export function extractProfileName(config: Record<string, unknown>): string | null {
+  // 1. Explicit profile field
+  const profile = config.profile;
+  if (typeof profile === "string" && profile.trim()) return profile.trim();
+
+  // 2. -p / --profile in extraArgs
+  const extraArgs = config.extraArgs;
+  if (Array.isArray(extraArgs)) {
+    for (let i = 0; i < extraArgs.length; i++) {
+      const arg = String(extraArgs[i]);
+      if (arg === "-p" || arg === "--profile") {
+        const next = extraArgs[i + 1];
+        if (typeof next === "string" && next.trim()) return next.trim();
+      }
+      const eqMatch = arg.match(/^--profile=(.+)$/);
+      if (eqMatch) return eqMatch[1].trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the effective HERMES_HOME directory.
+ *
+ * Priority:
+ *   1. Explicit HERMES_HOME in config.env
+ *   2. Profile name → ~/.hermes/profiles/<name>
+ *   3. Default → ~/.hermes
+ */
+export function resolveHermesHomeDir(config: Record<string, unknown>): string {
+  // 1. Explicit HERMES_HOME in env
+  const envConfig = config.env;
+  if (envConfig && typeof envConfig === "object" && !Array.isArray(envConfig)) {
+    const hermesHome = (envConfig as Record<string, unknown>).HERMES_HOME;
+    if (typeof hermesHome === "string" && hermesHome.trim()) {
+      return hermesHome.trim();
+    }
+    // Handle wrapped format: { type: "plain", value: "..." }
+    if (hermesHome && typeof hermesHome === "object" && "value" in hermesHome) {
+      const val = (hermesHome as Record<string, unknown>).value;
+      if (typeof val === "string" && val.trim()) return val.trim();
+    }
+  }
+
+  // 2. Profile name
+  const profile = extractProfileName(config);
+  if (profile) {
+    return path.join(os.homedir(), ".hermes", "profiles", profile);
+  }
+
+  // 3. Default
+  return path.join(os.homedir(), ".hermes");
+}

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -17,6 +17,54 @@ import {
 } from "../shared/constants.js";
 
 /**
+ * Parse KEY=VALUE lines from a multiline string.
+ * Skips blank lines and lines starting with #.
+ */
+export function parseEnvVars(text: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Parse env bindings that may carry {type:"plain",value} or
+ * {type:"secret_ref",secretId,version?} shapes.
+ */
+export function parseEnvBindings(bindings: unknown): Record<string, unknown> {
+  if (!bindings || typeof bindings !== "object" || Array.isArray(bindings)) {
+    return {};
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, binding] of Object.entries(
+    bindings as Record<string, unknown>,
+  )) {
+    if (typeof binding === "string") {
+      result[key] = { type: "plain" as const, value: binding };
+      continue;
+    }
+    if (!binding || typeof binding !== "object") continue;
+    const b = binding as Record<string, unknown>;
+    if (b["type"] === "plain") {
+      result[key] = b["value"];
+    } else if (b["type"] === "secret_ref") {
+      result[key] = {
+        secretId: b["secretId"],
+        ...(b["version"] !== undefined ? { version: b["version"] } : {}),
+      };
+    }
+  }
+  return result;
+}
+
+/**
  * Build a Hermes Agent adapter config from the Paperclip UI form values.
  */
 export function buildHermesConfig(
@@ -66,7 +114,7 @@ export function buildHermesConfig(
 
   // Extra CLI arguments
   if (v.extraArgs) {
-    ac.extraArgs = v.extraArgs.split(/\s+/).filter(Boolean);
+    ac.extraArgs = v.extraArgs.split(",").map((s) => s.trim()).filter(Boolean);
   }
 
   // Thinking/reasoning effort
@@ -79,6 +127,56 @@ export function buildHermesConfig(
   // Prompt template
   if (v.promptTemplate) {
     ac.promptTemplate = v.promptTemplate;
+  }
+
+  // Instructions file path
+  if (v.instructionsFilePath) {
+    ac.instructionsFilePath = v.instructionsFilePath;
+  }
+
+  // Bootstrap prompt
+  if (v.bootstrapPrompt) {
+    ac.bootstrapPromptTemplate = v.bootstrapPrompt;
+  }
+
+  // Environment variables — bindings take priority over plain text vars
+  const envFromBindings = parseEnvBindings(v.envBindings);
+  const envFromVars = parseEnvVars(v.envVars ?? "");
+  const mergedEnv: Record<string, unknown> = {
+    ...envFromVars,
+    ...envFromBindings,
+  };
+  if (Object.keys(mergedEnv).length > 0) {
+    ac.env = mergedEnv;
+  }
+
+  // Provider override (from adapter-specific schema values).
+  // adapterSchemaValues is not yet part of the published CreateConfigValues
+  // type but may be present at runtime when the Paperclip host is newer.
+  const schemaValues = (v as unknown as Record<string, unknown>)[
+    "adapterSchemaValues"
+  ] as Record<string, unknown> | undefined;
+  const provider = schemaValues?.["provider"];
+  if (typeof provider === "string" && provider.trim()) {
+    ac.provider = provider.trim();
+  }
+
+  // Toolsets (from adapter-specific schema values)
+  const toolsets = schemaValues?.["toolsets"];
+  if (typeof toolsets === "string" && toolsets.trim()) {
+    ac.toolsets = toolsets.trim();
+  }
+
+  // Profile (from adapter-specific schema values)
+  // Persist profile name and inject -p flag so Hermes runs the right profile.
+  const profile = schemaValues?.["profile"];
+  if (typeof profile === "string" && profile.trim()) {
+    ac.profile = profile.trim();
+    const existing = (ac.extraArgs as string[]) || [];
+    if (!existing.includes("-p") && !existing.includes("--profile")) {
+      existing.push("-p", profile.trim());
+      ac.extraArgs = existing;
+    }
   }
 
   // Heartbeat config is handled by Paperclip itself

--- a/test/parse.test.mjs
+++ b/test/parse.test.mjs
@@ -1,0 +1,210 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseHermesOutput,
+  cleanResponse,
+  isHermesUnknownSessionError,
+  isHermesMaxTurnsResult,
+} from "../dist/server/parse.js";
+
+// ---------------------------------------------------------------------------
+// parseHermesOutput
+// ---------------------------------------------------------------------------
+
+describe("parseHermesOutput", () => {
+  it("extracts session ID from quiet mode output", () => {
+    const stdout = "Hello, I can help with that.\n\nsession_id: abc-123\n";
+    const result = parseHermesOutput(stdout, "");
+    assert.equal(result.sessionId, "abc-123");
+  });
+
+  it("extracts response text before session_id line", () => {
+    const stdout = "Hello world\n\nsession_id: xyz-999\n";
+    const result = parseHermesOutput(stdout, "");
+    assert.ok(result.response);
+    assert.ok(result.response.includes("Hello world"));
+    assert.ok(!result.response.includes("session_id:"));
+  });
+
+  it("extracts token usage from stdout", () => {
+    const stdout =
+      "Done.\n\nsession_id: s1\ntokens: 150 input, 42 output\n";
+    const result = parseHermesOutput(stdout, "");
+    assert.ok(result.usage, "usage should be present");
+    assert.equal(result.usage.inputTokens, 150);
+    assert.equal(result.usage.outputTokens, 42);
+  });
+
+  it("extracts token usage from stderr", () => {
+    const stderr = "tokens: 200 input, 80 output";
+    const result = parseHermesOutput("session_id: s1\n", stderr);
+    assert.ok(result.usage);
+    assert.equal(result.usage.inputTokens, 200);
+    assert.equal(result.usage.outputTokens, 80);
+  });
+
+  it("extracts cost from stdout", () => {
+    const stdout = "session_id: s2\ncost: $0.0042\n";
+    const result = parseHermesOutput(stdout, "");
+    assert.ok(result.costUsd !== undefined);
+    assert.ok(Math.abs(result.costUsd - 0.0042) < 1e-9);
+  });
+
+  it("extracts cost from stderr using 'spent' keyword", () => {
+    const stderr = "spent: 0.012";
+    const result = parseHermesOutput("session_id: s3\n", stderr);
+    assert.ok(result.costUsd !== undefined);
+    assert.ok(Math.abs(result.costUsd - 0.012) < 1e-9);
+  });
+
+  it("extracts error messages from stderr", () => {
+    const stderr = "Error: something went wrong\n";
+    const result = parseHermesOutput("", stderr);
+    assert.ok(result.errorMessage);
+    assert.ok(result.errorMessage.includes("Error: something went wrong"));
+  });
+
+  it("ignores stderr log-level noise when detecting errors", () => {
+    const stderr = "INFO: starting up\nDEBUG: verbose output\n";
+    const result = parseHermesOutput("", stderr);
+    assert.equal(result.errorMessage, undefined);
+  });
+
+  it("handles blank stdout and stderr gracefully", () => {
+    const result = parseHermesOutput("", "");
+    assert.equal(result.sessionId, undefined);
+    assert.equal(result.response, undefined);
+    assert.equal(result.usage, undefined);
+    assert.equal(result.costUsd, undefined);
+    assert.equal(result.errorMessage, undefined);
+  });
+
+  it("falls back to legacy session ID format", () => {
+    const stdout = "Here is the answer.\nsession saved: legacy-id-456\n";
+    const result = parseHermesOutput(stdout, "");
+    assert.equal(result.sessionId, "legacy-id-456");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanResponse
+// ---------------------------------------------------------------------------
+
+describe("cleanResponse", () => {
+  it("strips [tool] lines", () => {
+    const raw = "[tool] running bash\nHello from assistant\n";
+    const cleaned = cleanResponse(raw);
+    assert.ok(!cleaned.includes("[tool]"));
+    assert.ok(cleaned.includes("Hello from assistant"));
+  });
+
+  it("strips [hermes] lines", () => {
+    const raw = "[hermes] initializing\nSome response text\n";
+    const cleaned = cleanResponse(raw);
+    assert.ok(!cleaned.includes("[hermes]"));
+    assert.ok(cleaned.includes("Some response text"));
+  });
+
+  it("strips [paperclip] lines", () => {
+    const raw = "[paperclip] dispatching\nAssistant reply\n";
+    const cleaned = cleanResponse(raw);
+    assert.ok(!cleaned.includes("[paperclip]"));
+    assert.ok(cleaned.includes("Assistant reply"));
+  });
+
+  it("strips session_id lines", () => {
+    const raw = "Good answer.\nsession_id: abc-123\n";
+    const cleaned = cleanResponse(raw);
+    assert.ok(!cleaned.includes("session_id:"));
+    assert.ok(cleaned.includes("Good answer."));
+  });
+
+  it("preserves assistant text", () => {
+    const raw = "This is the assistant's answer.\nIt spans multiple lines.\n";
+    const cleaned = cleanResponse(raw);
+    assert.ok(cleaned.includes("This is the assistant's answer."));
+    assert.ok(cleaned.includes("It spans multiple lines."));
+  });
+
+  it("strips ISO timestamp bracket lines", () => {
+    const raw = "[2024-03-15T12:34:56Z] system event\nReal text\n";
+    const cleaned = cleanResponse(raw);
+    assert.ok(!cleaned.includes("[2024-03-15T"));
+    assert.ok(cleaned.includes("Real text"));
+  });
+
+  it("collapses excessive blank lines", () => {
+    const raw = "Line one\n\n\n\nLine two\n";
+    const cleaned = cleanResponse(raw);
+    // should not have 3+ consecutive newlines
+    assert.ok(!/\n{3,}/.test(cleaned));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isHermesUnknownSessionError
+// ---------------------------------------------------------------------------
+
+describe("isHermesUnknownSessionError", () => {
+  it('detects "unknown session" in stdout', () => {
+    assert.equal(isHermesUnknownSessionError("Error: unknown session", ""), true);
+  });
+
+  it('detects "session not found" in stderr', () => {
+    assert.equal(isHermesUnknownSessionError("", "session not found"), true);
+  });
+
+  it('detects "session expired" case-insensitively', () => {
+    assert.equal(isHermesUnknownSessionError("Session Expired", ""), true);
+  });
+
+  it('detects "no conversation found"', () => {
+    assert.equal(isHermesUnknownSessionError("", "no conversation found"), true);
+  });
+
+  it('detects "invalid session"', () => {
+    assert.equal(isHermesUnknownSessionError("invalid session id provided", ""), true);
+  });
+
+  it("returns false for normal output", () => {
+    assert.equal(isHermesUnknownSessionError("All done.", "tokens: 10 in, 5 out"), false);
+  });
+
+  it("returns false for empty strings", () => {
+    assert.equal(isHermesUnknownSessionError("", ""), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isHermesMaxTurnsResult
+// ---------------------------------------------------------------------------
+
+describe("isHermesMaxTurnsResult", () => {
+  it('detects "max turns reached" in stdout', () => {
+    assert.equal(isHermesMaxTurnsResult("max turns reached", ""), true);
+  });
+
+  it('detects "max_turns exceeded" in stderr', () => {
+    assert.equal(isHermesMaxTurnsResult("", "max_turns exceeded"), true);
+  });
+
+  it('detects "reached the max turns" phrasing', () => {
+    assert.equal(isHermesMaxTurnsResult("reached the max turns", ""), true);
+  });
+
+  it("does not false-positive on help text mentioning --max-turns flag", () => {
+    assert.equal(isHermesMaxTurnsResult("use --max-turns to set a limit", ""), false);
+  });
+
+  it("is case-insensitive", () => {
+    assert.equal(isHermesMaxTurnsResult("MAX TURNS REACHED", ""), true);
+  });
+
+  it("returns false for normal output", () => {
+    assert.equal(isHermesMaxTurnsResult("Task complete.", ""), false);
+  });
+
+  it("returns false for empty strings", () => {
+    assert.equal(isHermesMaxTurnsResult("", ""), false);
+  });
+});


### PR DESCRIPTION
## Summary

Rewrites the Hermes adapter for full feature parity with claude-local and codex-local while preserving Hermes-specific strengths (multi-provider routing, profile isolation, 30+ native tools). 14 files changed, 1415 insertions, 340 deletions.

Consolidates fixes from issues #2, #5, #13, #14, #24, #27 and community PRs #1, #4, #17, #23, #25, #26, #29. Credits to @fa1k3, @shivasymbl, @optomachina, @lucasproko, @ScaleLeanChris, @mattverlaque, @AnandDN, and @Superversive.

## Changes

### execute.ts (major rewrite)

**Prompt construction** — Replaced 66-line hardcoded prompt template (inline curl examples, conditional sections, hardcoded API URL builder) with a minimal default template. Workflow instructions are provided by the `paperclip` skill injected at runtime. Prompt composed via `joinPromptSections()`: instructions + bootstrap + wake + handoff + heartbeat. Prompt section sizes tracked in `promptMetrics` and reported via `onMeta`.

**Skill injection** — Creates real directories in `~/.hermes/skills/paperclip/<name>/` with symlinked files inside (Python's `pathlib.rglob()` does not follow directory symlinks). Skills preloaded via Hermes `-s` flag as `paperclip/<name>`. Profile-aware: resolves to `~/.hermes/profiles/<name>/skills/` when `-p` is used.

**Billing type detection** — Anthropic without `ANTHROPIC_API_KEY` → `"subscription"` (Claude Pro/Team login). Copilot/Copilot-ACP without `OPENAI_API_KEY` → `"subscription"`. All other providers → `"api"`. Matches claude-local/codex-local/cursor-local/gemini-local pattern.

**Cost from state.db** — Queries `~/.hermes/state.db` after execution for `estimated_cost_usd` and token counts. Quiet mode (`-Q`) emits no cost/token lines to stdout; state.db is the source of truth. Profile-aware. Requires Node 22+ (`node:sqlite`); non-fatal on older versions.

**Wake context** — Reads task/comment/wake fields from `ctx.context` (not `ctx.config`). Uses structured `renderPaperclipWakePrompt()` when available. Passes all `PAPERCLIP_*` env vars: workspace, runtime services, linked issues, wake payload JSON, approval status.

**Instructions file** — Reads `config.instructionsFilePath` (AGENTS.md from Instructions tab), prepends to prompt. Mirrors claude-local `--append-system-prompt-file`.

**Execution metadata** — Calls `ctx.onMeta` with command, args, cwd, redacted env, prompt, `promptMetrics`. Forwards `ctx.onSpawn` for PID tracking.

**Session lifecycle** — Validates CWD match before resuming. Retries with fresh session on unknown-session error. Stores `cwd`, `workspaceId`, `repoUrl`, `repoRef` in `sessionParams`.

**Env var handling** — Unwraps `{ type: "plain", value: "..." }` format. Injects `ctx.authToken` as `PAPERCLIP_API_KEY` with guard against overwrite. Resolves workspace CWD from context.

**Smart stderr filter** — Reclassifies benign stderr noise (MCP init, timestamps, log-level lines) as stdout. Skill security warnings referencing the agent's own profile skills path are prefixed with `[hermes]` and reclassified (Hermes hardcodes `~/.hermes/skills/` as trusted but profile skills live elsewhere). Warnings from unknown paths pass through as stderr.

### New files

| File | Description |
|---|---|
| `src/server/parse.ts` | Output parsing: `parseHermesOutput()`, `cleanResponse()`, `isHermesUnknownSessionError()`, `isHermesMaxTurnsResult()`. Supports quiet-mode and legacy formats. |
| `src/shared/profile.ts` | `resolveHermesHomeDir()` and `extractProfileName()`. Resolves HERMES_HOME from `config.env.HERMES_HOME`, `-p`/`--profile` in extraArgs, `config.profile`, or default `~/.hermes`. Used by execute, detect-model, skills, state.db. |
| `src/server/config-schema.ts` | `getConfigSchema()`: dynamic provider combobox (13 providers), profile dropdown (scans `~/.hermes/profiles/`), toolsets text field. |
| `src/server/quota.ts` | Placeholder `getQuotaWindows()` returning empty-but-valid `ProviderQuotaResult`. |
| `test/parse.test.mjs` | 31 tests covering session ID extraction, token parsing, cost extraction, error detection, response cleaning, unknown session detection, max-turns detection. |

### src/index.ts

Exports `supportsLocalAgentJwt = true`, all server functions (`execute`, `sessionCodec`, `listSkills`, `syncSkills`, `testEnvironment`, `detectModel`, `getConfigSchema`, `getQuotaWindows`), and `createServerAdapter()` factory for plugin-loader compatibility.

### src/server/detect-model.ts

Accepts optional `adapterConfig` and resolves config.yaml path through `resolveHermesHomeDir()` for profile-aware model detection.

### src/server/skills.ts

Uses shared `resolveHermesHomeDir()` for profile-aware skill scanning. Detail message: "Will be injected into the Hermes skills directory on the next run." (matches claude-local/codex-local pattern).

### src/server/index.ts

Exports `parseHermesOutput`, `isHermesUnknownSessionError`, `isHermesMaxTurnsResult`, `cleanResponse`, `getConfigSchema`, `getQuotaWindows`. Session codec stores `cwd`, `workspaceId`, `repoUrl`, `repoRef` alongside `sessionId`.

### src/server/test.ts

Adds `checkCwd()`, `checkHelloProbe()` (live probe, 45s timeout), `checkProviderConsistency()`.

### src/ui/build-config.ts

Full `buildHermesConfig()`: model, timeoutSec, maxTurnsPerRun, cwd, command, extraArgs (comma-separated, matching claude-local), promptTemplate, instructionsFilePath, bootstrapPromptTemplate, env vars (plain + secret_ref), provider, toolsets, profile (persisted + injected as `-p` flag).

### package.json

Version 0.2.1 → 0.4.0. `prepublishOnly: "npm run build"`. `test` script added.

## Test plan

- [x] `npm run build` — clean TypeScript compilation
- [x] `npm run typecheck` — no type errors
- [x] `npm test` — 31/31 tests pass
- [x] Manual heartbeat: skills injected and preloaded via `-s` flag
- [x] Manual heartbeat: AGENTS.md instructions injected into prompt
- [x] Manual heartbeat: onMeta reports full invocation detail
- [x] Manual heartbeat: session ID parsed, cost queried from state.db
- [x] Manual heartbeat: profile-aware (`-p floating-ceo` sessions in profile state.db)
- [x] Manual heartbeat: Gmail working via GWS CLI with profile-specific creds
- [x] Smart stderr filter: skill security warnings render as system, not errors
- [ ] Verify billing type shows "subscription" for Claude subscription users

🤖 Generated with [Claude Code](https://claude.ai/claude-code)