### PR TITLE
fix: default DEFAULT_MODEL to 'auto' instead of hardcoded Anthropic model

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -17,8 +17,15 @@ export const DEFAULT_TIMEOUT_SEC = 1800;
 /** Grace period after SIGTERM before SIGKILL (seconds). */
 export const DEFAULT_GRACE_SEC = 10;
 
-/** Default model to use if none specified. */
-export const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
+/**
+ * Default model to use if none specified.
+ *
+ * Use "auto" so that Hermes resolves the model from the user's local
+ * ~/.hermes/config.yaml — preventing the adapter from overriding a
+ * user's configured default (e.g. MiniMax, OpenRouter, etc.) with a
+ * hardcoded Anthropic model during Paperclip onboarding.
+ */
+export const DEFAULT_MODEL = "auto";
 
 /**
  * Valid --provider choices for the hermes CLI.


### PR DESCRIPTION
## Problem

The `DEFAULT_MODEL` constant is hardcoded to `"anthropic/claude-sonnet-4"`. When a user onboards a Hermes agent in Paperclip without explicitly configuring a model, this hardcoded default causes the adapter to route requests through Anthropic — even when the user has configured a completely different provider (e.g. MiniMax-CN, OpenRouter, etc.) in their local `~/.hermes/config.yaml`.

This results in silent failures: the user sees "No Anthropic credentials found" because Hermes falls back to querying an Anthropic API that isn't configured.

## Fix

Change `DEFAULT_MODEL` from `"anthropic/claude-sonnet-4"` to `"auto"` — Hermes's own auto-detection model name, which delegates to the user's configured default from `~/.hermes/config.yaml`.

**Priority chain for model resolution remains unchanged:**
1. Explicit `model` in Paperclip agent config (user override — highest priority)
2. `DEFAULT_MODEL` fallback (now `"auto"` instead of hardcoded Anthropic)

**Priority chain for provider resolution (already implemented via `resolveProvider`):**
1. Explicit `provider` in adapter config
2. Provider from `~/.hermes/config.yaml` (if model matches)
3. Inferred from model name prefix
4. `"auto"` (let Hermes decide)

With `model="auto"` and `provider="auto"", Hermes uses its own configured default — respecting whatever the user has already set up locally.

## Backward compatibility

- Users who explicitly set `model: anthropic/claude-sonnet-4` in their Paperclip agent config will see no change
- Users who don't set any model (the onboarding case this fixes) will now get their actual configured default instead of a hardcoded Anthropic model

Closes #(issue number if applicable)