### PR TITLE
feat: load agent instructionsFilePath and prepend to prompt

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -367,16 +367,20 @@ export async function execute(
   if (instructionsFilePath) {
     try {
       agentInstructions = await fs.readFile(instructionsFilePath, "utf-8");
+      const loadedInstructionsLength = agentInstructions.length;
       const instructionsFileDir = path.dirname(instructionsFilePath);
       agentInstructions += `\nThe above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsFileDir}/.`;
       await ctx.onLog(
         "stdout",
-        `[hermes] Loaded agent instructions from ${instructionsFilePath} (${agentInstructions.length} chars)\n`,
+        `[hermes] Loaded agent instructions from ${instructionsFilePath} (${loadedInstructionsLength} chars)\n`,
       );
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
+      // Non-fatal: log to stdout with an explicit "Warning:" prefix so the
+      // Paperclip UI doesn't render this as a red error (stderr output is
+      // surfaced as an error signal even when execution continues).
       await ctx.onLog(
-        "stderr",
+        "stdout",
         `[hermes] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
       );
     }

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -18,6 +18,9 @@
  *   --source           session source tag for filtering
  */
 
+import fs from "node:fs/promises";
+import path from "node:path";
+
 import type {
   AdapterExecutionContext,
   AdapterExecutionResult,
@@ -354,8 +357,36 @@ export async function execute(
     model,
   });
 
+  // ── Load agent instructions file (Paperclip instruction bundles) ──────
+  // Built-in adapters (claude_local, codex_local, gemini_local) read the
+  // instructionsFilePath from adapterConfig and inject it into the agent
+  // prompt. The hermes adapter was missing this — so curated instruction
+  // files (AGENTS.md, SOUL.md, HEARTBEAT.md, TOOLS.md) were never read.
+  const instructionsFilePath = cfgString(config.instructionsFilePath);
+  let agentInstructions = "";
+  if (instructionsFilePath) {
+    try {
+      agentInstructions = await fs.readFile(instructionsFilePath, "utf-8");
+      const instructionsFileDir = path.dirname(instructionsFilePath);
+      agentInstructions += `\nThe above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsFileDir}/.`;
+      await ctx.onLog(
+        "stdout",
+        `[hermes] Loaded agent instructions from ${instructionsFilePath} (${agentInstructions.length} chars)\n`,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await ctx.onLog(
+        "stderr",
+        `[hermes] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+
   // ── Build prompt ───────────────────────────────────────────────────────
-  const prompt = buildPrompt(ctx, config);
+  let prompt = buildPrompt(ctx, config);
+  if (agentInstructions) {
+    prompt = agentInstructions + "\n\n---\n\n" + prompt;
+  }
 
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line


### PR DESCRIPTION
## Summary

The built-in Paperclip adapters (`claude_local`, `codex_local`, `gemini_local`) all read `instructionsFilePath` from `adapterConfig` and inject the file's contents into the agent's prompt. This is the mechanism Paperclip uses to ship curated instruction bundles to agents — `AGENTS.md`, `SOUL.md`, `HEARTBEAT.md`, `TOOLS.md`, etc.

The Hermes adapter was missing this. Agents configured with `instructionsFilePath` saw the file listed in their Paperclip config, but the adapter never actually read the file, so every hermes-backed agent ran with only the default prompt template — no curated identity, no operational guardrails, no tool documentation.

## What this PR does

- Reads `config.instructionsFilePath` if set
- Prepends the file contents to the prompt, separated by `---`
- Appends a footer telling the agent where to resolve relative file references from (`path.dirname(instructionsFilePath)`)
- Logs success (char count) to stdout / failure reason to stderr
- **Errors are non-fatal** — if the file is missing or unreadable, we log a warning and fall through to the normal prompt build, matching the behavior of the built-in adapters

## Diff

`src/server/execute.ts`: +32 / -1 (plus two `import` lines for `node:fs/promises` and `node:path`).

```ts
const instructionsFilePath = cfgString(config.instructionsFilePath);
let agentInstructions = "";
if (instructionsFilePath) {
  try {
    agentInstructions = await fs.readFile(instructionsFilePath, "utf-8");
    const instructionsFileDir = path.dirname(instructionsFilePath);
    agentInstructions += `\nThe above agent instructions were loaded from ${instructionsFilePath}. Resolve any relative file references from ${instructionsFileDir}/.`;
    await ctx.onLog("stdout", `[hermes] Loaded agent instructions from ${instructionsFilePath} (${agentInstructions.length} chars)\n`);
  } catch (err) {
    const reason = err instanceof Error ? err.message : String(err);
    await ctx.onLog("stderr", `[hermes] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`);
  }
}

let prompt = buildPrompt(ctx, config);
if (agentInstructions) {
  prompt = agentInstructions + "\n\n---\n\n" + prompt;
}
```

## Test plan

- [x] Verified against a running Paperclip fleet with 7 hermes-backed agents (CEO, Research Scout, Chief Analyst, etc.) — all load their curated `AGENTS.md` / `SOUL.md` bundles at every run.
- [x] Before this fix, the same fleet ran with only the default prompt template — every agent reported a generic "Hermes Agent" identity with no project context.
- [x] Missing file path is handled gracefully (warning logged, execution continues).
- [ ] CI typecheck + tests (please run on merge).

## Why this matches built-in adapters

All three built-in `*_local` adapters in paperclipai/paperclip use the same `instructionsFilePath` config field and inject it into the agent prompt the same way. This brings the hermes adapter in line with that contract — agents configured through the normal Paperclip instruction-bundle workflow just work.