### PR TITLE
fix: honour adapterConfig.command as fallback for hermesCommand

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -315,7 +315,13 @@ export async function execute(
   const config = (ctx.config ?? ctx.agent?.adapterConfig ?? {}) as Record<string, unknown>;
 
   // ── Resolve configuration ──────────────────────────────────────────────
-  const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
+  // Accept both `hermesCommand` (canonical, set by buildHermesConfig on
+  // create) and `command` (raw field name stored by the UI edit/update
+  // path and by direct API callers). Without the `command` fallback a
+  // custom hermes profile wrapper set through the UI is silently ignored
+  // and the adapter spawns the default `hermes` binary instead. See #24.
+  const hermesCmd =
+    cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
   const model = cfgString(config.model) || DEFAULT_MODEL;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;


### PR DESCRIPTION
## Summary

Fixes #24 — custom hermes profile wrappers set via the Paperclip UI are silently ignored and the adapter spawns the default \`hermes\` binary.

## Root cause (from issue #24)

- The Paperclip UI form stores the \"Command\" field as \`adapterConfig.command\`.
- \`buildHermesConfig()\` in \`build-config.ts\` translates \`v.command\` → \`ac.hermesCommand\` on **create** only.
- The UI edit/update path and direct API callers write the raw field name \`command\` back without going through \`buildHermesConfig()\`.
- \`execute.ts:318\` only reads \`config.hermesCommand\`, so the custom command is dropped on the floor and \`HERMES_CLI\` (\`hermes\`) is used instead — which uses the default \`~/.hermes\` home, ignoring the intended profile entirely.

## Fix

One line, additive, read-time fallback:

\`\`\`ts
const hermesCmd =
  cfgString(config.hermesCommand)
  || cfgString(config.command)
  || HERMES_CLI;
\`\`\`

This is the fix the issue author proposed. It's backwards-compatible: agents already storing \`hermesCommand\` see no change. Agents storing \`command\` (UI edits, direct API) now resolve correctly.

## Why not also fix \`buildHermesConfig()\`?

We could also patch the update path to always translate \`command\` → \`hermesCommand\` symmetrically with create. But:
1. That still leaves pre-existing agents in the database broken until they're next touched.
2. The read-time fallback covers both the update path AND the direct-API path in a single surgical change.
3. The two fields are semantically identical — there's no reason the adapter should reject one naming.

If a cleanup PR later renames all stored fields to \`hermesCommand\`, this fallback becomes a no-op (and can be removed). Until then it unblocks every affected user immediately.

## Test plan

- [x] Verified the bug repros on our local fleet — agents with Command = \`hermes_maximus\` were spawning default \`hermes\`.
- [x] Verified the fix resolves the custom command path after rebuild.
- [ ] CI typecheck + tests (please run on merge).

## Related

- #24 — the bug report (this PR)
- #22 — similar config resolution fix (ctx.config vs ctx.agent.adapterConfig) — already merged
- #35 — unrelated, concurrent PR adding \`instructionsFilePath\` loading in the same file