### PR TITLE
fix: read ~/.hermes/.env in testEnvironment API key check

### DIFF
--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -12,6 +12,7 @@ import type {
 } from "@paperclipai/adapter-utils";
 
 import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { promisify } from "node:util";
 
 import { HERMES_CLI, DEFAULT_MODEL, ADAPTER_TYPE, VALID_PROVIDERS } from "../shared/constants.js";
@@ -135,15 +136,38 @@ function checkApiKeys(
 ): AdapterEnvironmentCheck | null {
   // The server resolves secret refs into config.env before calling testEnvironment,
   // so we check config.env first (adapter-configured secrets), then fall back to
-  // process.env (server/host environment). This mirrors how the Claude adapter does it.
+  // process.env (server/host environment), then ~/.hermes/.env (Hermes local config).
   const envConfig = (config.env ?? {}) as Record<string, unknown>;
   const resolvedEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string" && value.length > 0) resolvedEnv[key] = value;
   }
 
+  // Also read ~/.hermes/.env — Hermes stores API keys there by default and does
+  // not export them to the parent process, so Paperclip's process.env won't
+  // contain them.  Parsing this file ensures the environment test reports
+  // accurate results for keys that Hermes already knows about.
+  const hermesEnvKeys: Record<string, string> = {};
+  try {
+    const homeDir = process.env.HOME || process.env.USERPROFILE || "/root";
+    const hermesEnvPath = `${homeDir}/.hermes/.env`;
+    const content = readFileSync(hermesEnvPath, "utf-8");
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eqIdx = trimmed.indexOf("=");
+      if (eqIdx > 0) {
+        const key = trimmed.substring(0, eqIdx).trim();
+        const value = trimmed.substring(eqIdx + 1).trim();
+        if (value.length > 0) hermesEnvKeys[key] = value;
+      }
+    }
+  } catch {
+    // ~/.hermes/.env may not exist — that's fine
+  }
+
   const has = (key: string): boolean =>
-    !!(resolvedEnv[key] ?? process.env[key]);
+    !!(resolvedEnv[key] ?? process.env[key] ?? hermesEnvKeys[key]);
 
   const hasAnthropic = has("ANTHROPIC_API_KEY");
   const hasOpenRouter = has("OPENROUTER_API_KEY");


### PR DESCRIPTION
## Summary

When clicking "Test environment" in Paperclip for a Hermes adapter, the environment test always reported "No LLM API keys found" with a warn status, even when API keys were properly configured in ~/.hermes/.env.

The root cause: Hermes Agent stores API keys in ~/.hermes/.env and loads them at runtime — it does not export them to the parent process environment. Paperclip's Node.js server process therefore has no visibility into these keys via process.env. The checkApiKeys() function in src/server/test.ts only checked config.env (Paperclip adapter secrets) and process.env (server environment), missing the Hermes-local env file entirely.

## What this PR does

- src/server/test.ts: Added readFileSync import and a fallback in checkApiKeys() that parses ~/.hermes/.env into a hermesEnvKeys map. The has() lookup chain is now: config.env -> process.env -> ~/.hermes/.env.

## Verification

1. npx tsc --noEmit passes cleanly
2. Manually verified: with ZAI_API_KEY in ~/.hermes/.env and nowhere else, the test now returns "API keys found: Z.AI" instead of the false warning