### PR TITLE
fix: load Paperclip skills into Hermes execution prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test:skill-prompt": "npm run build && node --test dist/server/execute.skills.test.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/src/server/execute.skills.test.ts
+++ b/src/server/execute.skills.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { buildExecutionPrompt } from "./execute.js";
+import { buildDesiredSkillPromptData } from "./skills.js";
+
+async function withTempSkill<T>(fn: (skillRoot: string) => Promise<T>): Promise<T> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-skill-"));
+  const skillRoot = path.join(tempDir, "copywriting");
+  await fs.mkdir(skillRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(skillRoot, "SKILL.md"),
+    [
+      "---",
+      "name: copywriting",
+      "description: Copywriting workflow",
+      "---",
+      "Use tight, conversion-focused copy.",
+    ].join("\n"),
+    "utf8",
+  );
+
+  try {
+    return await fn(skillRoot);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function buildConfig(skillRoot: string): Record<string, unknown> {
+  return {
+    paperclipRuntimeSkills: [
+      {
+        key: "copywriting",
+        runtimeName: "copywriting",
+        source: skillRoot,
+      },
+    ],
+    paperclipSkillSync: {
+      desiredSkills: ["copywriting"],
+    },
+  };
+}
+
+test("buildDesiredSkillPromptData loads selected runtime skill markdown", async () => {
+  await withTempSkill(async (skillRoot) => {
+    const result = await buildDesiredSkillPromptData(buildConfig(skillRoot));
+
+    assert.deepEqual(result.desiredSkillNames, ["copywriting"]);
+    assert.equal(result.warnings.length, 0);
+    assert.match(result.promptSection, /# Paperclip-managed runtime skills/);
+    assert.match(result.promptSection, /Use tight, conversion-focused copy\./);
+  });
+});
+
+test("buildExecutionPrompt prepends skill instructions before wake prompt", async () => {
+  await withTempSkill(async (skillRoot) => {
+    const prompt = await buildExecutionPrompt(
+      {
+        agent: {
+          id: "agent-1",
+          name: "Skill Agent",
+          companyId: "company-1",
+        },
+        config: {
+          companyName: "Acme",
+          projectName: "Demo",
+        },
+      } as any,
+      buildConfig(skillRoot),
+    );
+
+    const skillIndex = prompt.indexOf("# Paperclip-managed runtime skills");
+    const wakeIndex = prompt.indexOf("## Heartbeat Wake — Check for Work");
+
+    assert.ok(skillIndex >= 0, "skill section should exist");
+    assert.ok(wakeIndex >= 0, "wake prompt should exist");
+    assert.ok(skillIndex < wakeIndex, "skill section should come before wake prompt");
+  });
+});

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -29,6 +29,7 @@ import {
   buildPaperclipEnv,
   renderTemplate,
   ensureAbsoluteDirectory,
+  joinPromptSections,
 } from "@paperclipai/adapter-utils/server-utils";
 
 import {
@@ -43,6 +44,7 @@ import {
   detectModel,
   resolveProvider,
 } from "./detect-model.js";
+import { buildDesiredSkillPromptData } from "./skills.js";
 
 // ---------------------------------------------------------------------------
 // Config helpers
@@ -123,7 +125,7 @@ Address the comment, POST a reply if needed, then continue working.
 4. If truly nothing to do, report briefly what you checked.
 {{/noTask}}`;
 
-function buildPrompt(
+export function buildPrompt(
   ctx: AdapterExecutionContext,
   config: Record<string, unknown>,
 ): string {
@@ -186,6 +188,17 @@ function buildPrompt(
 
   // Replace remaining {{variable}} placeholders
   return renderTemplate(rendered, vars);
+}
+
+export async function buildExecutionPrompt(
+  ctx: AdapterExecutionContext,
+  config: Record<string, unknown>,
+): Promise<string> {
+  const skillPrompt = await buildDesiredSkillPromptData(config);
+  return joinPromptSections([
+    skillPrompt.promptSection,
+    buildPrompt(ctx, config),
+  ]);
 }
 
 // ---------------------------------------------------------------------------
@@ -355,7 +368,7 @@ export async function execute(
   });
 
   // ── Build prompt ───────────────────────────────────────────────────────
-  const prompt = buildPrompt(ctx, config);
+  const prompt = await buildExecutionPrompt(ctx, config);
 
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line

--- a/src/server/skills.ts
+++ b/src/server/skills.ts
@@ -39,6 +39,12 @@ interface SkillFrontmatter {
   metadata?: Record<string, unknown>;
 }
 
+export interface DesiredSkillPromptData {
+  desiredSkillNames: string[];
+  promptSection: string;
+  warnings: string[];
+}
+
 function parseSkillFrontmatter(content: string): SkillFrontmatter {
   const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
   if (!match) return {};
@@ -225,4 +231,46 @@ export function resolveHermesDesiredSkillNames(
   availableEntries: Array<{ key: string; required?: boolean }>,
 ): string[] {
   return resolvePaperclipDesiredSkillNames(config, availableEntries);
+}
+
+export async function buildDesiredSkillPromptData(
+  config: Record<string, unknown>,
+): Promise<DesiredSkillPromptData> {
+  const availableEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
+  const desiredSkillNames = resolvePaperclipDesiredSkillNames(config, availableEntries);
+  const warnings: string[] = [];
+  const sections: string[] = [];
+
+  for (const skillName of desiredSkillNames) {
+    const entry = availableEntries.find((candidate) => candidate.key === skillName);
+    if (!entry) {
+      warnings.push(`Desired Paperclip skill "${skillName}" is not available at runtime.`);
+      continue;
+    }
+
+    try {
+      const markdown = await fs.readFile(path.join(entry.source, "SKILL.md"), "utf8");
+      sections.push(`## Skill: ${entry.runtimeName}\n\n${markdown.trim()}`);
+    } catch {
+      warnings.push(`Desired Paperclip skill "${skillName}" is missing source/SKILL.md.`);
+    }
+  }
+
+  if (sections.length === 0) {
+    return {
+      desiredSkillNames,
+      promptSection: "",
+      warnings,
+    };
+  }
+
+  return {
+    desiredSkillNames,
+    promptSection: [
+      "# Paperclip-managed runtime skills",
+      "Apply these company-managed skills before the normal wake/task instructions.",
+      ...sections,
+    ].join("\n\n"),
+    warnings,
+  };
 }


### PR DESCRIPTION
## Summary
- load Paperclip-selected runtime SKILL.md content into the actual Hermes execution prompt
- add a regression gate for prompt composition (`test:skill-prompt`)
- route #37 into one canonical merge lane for #39

## Why
Issue #37 had repeated local-only evidence, but the adapter still did not inject selected Paperclip skills into Hermes sessions on `main`.

## Verification
- `npm run typecheck`
- `npm run test:skill-prompt`

## Dependency note
- #20 is **not** a hard dependency for this patch; this prompt-composition fix works with the current runtime-skill source paths.
- #39 tracks the merge/release lane for this fix.

Closes #37
Refs #39
