### PR TITLE
fix: honour command field in runtime and env test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test:command-resolution": "npm run build && node --test dist/server/command-resolution.test.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/src/server/command-resolution.test.ts
+++ b/src/server/command-resolution.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+
+import { HERMES_CLI } from "../shared/constants.js";
+import { resolveHermesCommand } from "./execute.js";
+import { testEnvironment } from "./test.js";
+
+test("resolveHermesCommand prefers hermesCommand over command", () => {
+  assert.equal(
+    resolveHermesCommand({ hermesCommand: "hermes_maximus", command: "hermes_backup" }),
+    "hermes_maximus",
+  );
+});
+
+test("resolveHermesCommand falls back to command before default hermes binary", () => {
+  assert.equal(resolveHermesCommand({ command: "hermes_maximus" }), "hermes_maximus");
+  assert.equal(resolveHermesCommand({}), HERMES_CLI);
+});
+
+test("testEnvironment accepts config.command when hermesCommand is absent", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "hermes-command-resolution-"));
+  const cliPath = path.join(tempDir, "fake-hermes");
+
+  try {
+    await writeFile(
+      cliPath,
+      "#!/bin/sh\necho fake-hermes 1.2.3\n",
+      "utf8",
+    );
+    await chmod(cliPath, 0o755);
+
+    const result = await testEnvironment({
+      companyId: "company-test",
+      adapterType: "hermes_local",
+      config: {
+        command: cliPath,
+      },
+    });
+
+    assert.notEqual(result.status, "fail");
+    assert.equal(
+      result.checks.some((check) => check.code === "hermes_cli_not_found"),
+      false,
+    );
+    assert.equal(
+      result.checks.some(
+        (check) => check.code === "hermes_version" && check.message.includes("fake-hermes 1.2.3"),
+      ),
+      true,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -63,6 +63,10 @@ function cfgStringArray(v: unknown): string[] | undefined {
     : undefined;
 }
 
+export function resolveHermesCommand(config: Record<string, unknown>): string {
+  return cfgString(config.hermesCommand) || cfgString(config.command) || HERMES_CLI;
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -315,7 +319,7 @@ export async function execute(
   const config = (ctx.config ?? ctx.agent?.adapterConfig ?? {}) as Record<string, unknown>;
 
   // ── Resolve configuration ──────────────────────────────────────────────
-  const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
+  const hermesCmd = resolveHermesCommand(config);
   const model = cfgString(config.model) || DEFAULT_MODEL;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;

--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -16,6 +16,7 @@ import { promisify } from "node:util";
 
 import { HERMES_CLI, DEFAULT_MODEL, ADAPTER_TYPE, VALID_PROVIDERS } from "../shared/constants.js";
 import { detectModel, resolveProvider, inferProviderFromModel } from "./detect-model.js";
+import { resolveHermesCommand } from "./execute.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -244,7 +245,7 @@ export async function testEnvironment(
   ctx: AdapterEnvironmentTestContext,
 ): Promise<AdapterEnvironmentTestResult> {
   const config = (ctx.config ?? {}) as Record<string, unknown>;
-  const command = asString(config.hermesCommand) || HERMES_CLI;
+  const command = resolveHermesCommand(config);
   const checks: AdapterEnvironmentCheck[] = [];
 
   // 1. CLI installed?


### PR DESCRIPTION
## Root cause
`src/server/execute.ts` and `src/server/test.ts` only honored `adapterConfig.hermesCommand`, even though the Paperclip UI/API can persist the same binary path as `adapterConfig.command`. That made runtime execution and environment checks silently fall back to the default `hermes` binary when only `command` was set.

## Files changed
- `src/server/execute.ts`
- `src/server/test.ts`
- `src/server/command-resolution.test.ts`
- `package.json`

## Diff summary
- added exported `resolveHermesCommand(config)` helper with fallback order `hermesCommand -> command -> HERMES_CLI`
- switched both runtime execution and `testEnvironment()` to use the shared resolver
- added `src/server/command-resolution.test.ts` regression coverage
- added `npm run test:command-resolution`

## Verification
- `npm run typecheck` ✅
- `npm run test:command-resolution` ✅
  - internally runs `npm run build && node --test dist/server/command-resolution.test.js`
  - result: 3/3 passing

## Related
- Fixes #24
- Supersedes the one-line-only PR shape in #36 by adding regression coverage for both execute + env-test paths.
