### PR TITLE
fix: defer to Hermes runtime config when provider inference is ambiguous

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test tests/*.test.mjs",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/src/server/detect-model.ts
+++ b/src/server/detect-model.ts
@@ -2,7 +2,7 @@
  * Detect the current model and provider from the user's Hermes config.
  *
  * Reads ~/.hermes/config.yaml and extracts the default model,
- * provider, base_url, and api_mode settings.
+ * provider, base_url, api_key presence, and api_mode settings.
  *
  * Also provides provider resolution logic that merges explicit config,
  * Hermes config detection, and model-name prefix inference.
@@ -20,6 +20,8 @@ export interface DetectedModel {
   provider: string;
   /** Base URL override from config (e.g. "https://api.githubcopilot.com"). May be empty. */
   baseUrl: string;
+  /** Whether Hermes config includes a non-empty API key. */
+  hasApiKey: boolean;
   /** API mode from config (e.g. "chat_completions", "codex_responses"). May be empty. */
   apiMode: string;
   /** Where the detection came from */
@@ -45,7 +47,7 @@ export async function detectModel(
 }
 
 /**
- * Parse model.default, model.provider, model.base_url, and model.api_mode
+ * Parse model.default, model.provider, model.base_url, model.api_key, and model.api_mode
  * from raw YAML content. Uses simple regex parsing to avoid a YAML dependency.
  */
 export function parseModelFromConfig(content: string): DetectedModel | null {
@@ -53,6 +55,7 @@ export function parseModelFromConfig(content: string): DetectedModel | null {
   let model = "";
   let provider = "";
   let baseUrl = "";
+  let hasApiKey = false;
   let apiMode = "";
   let inModelSection = false;
   let modelSectionIndent = 0;
@@ -81,6 +84,7 @@ export function parseModelFromConfig(content: string): DetectedModel | null {
         if (key === "default") model = val;
         if (key === "provider") provider = val;
         if (key === "base_url") baseUrl = val;
+        if (key === "api_key") hasApiKey = val.length > 0;
         if (key === "api_mode") apiMode = val;
       }
     }
@@ -88,7 +92,7 @@ export function parseModelFromConfig(content: string): DetectedModel | null {
 
   if (!model) return null;
 
-  return { model, provider, baseUrl, apiMode, source: "config" };
+  return { model, provider, baseUrl, hasApiKey, apiMode, source: "config" };
 }
 
 /**
@@ -122,8 +126,10 @@ export function inferProviderFromModel(model: string): string | undefined {
  *   1. Explicit provider from adapterConfig (highest priority — user override)
  *   2. Provider from Hermes config file — ONLY if the config model matches
  *      the requested model (otherwise the config provider is for a different model)
- *   3. Provider inferred from model name prefix
- *   4. "auto" (let Hermes figure it out — lowest priority)
+ *   3. If Hermes config matches the requested model but uses runtime settings that
+ *      the adapter cannot represent directly, return "auto" and let Hermes resolve it itself
+ *   4. Provider inferred from model name prefix
+ *   5. "auto" (let Hermes figure it out — lowest priority)
  *
  * Always returns a valid provider string.
  * The `resolvedFrom` field indicates which source was used, useful for logging.
@@ -135,30 +141,70 @@ export function resolveProvider(options: {
   detectedProvider?: string;
   /** Model name from Hermes config file (to check consistency) */
   detectedModel?: string;
+  /** Base URL detected from Hermes config file */
+  detectedBaseUrl?: string;
+  /** Whether Hermes config includes a non-empty API key */
+  detectedHasApiKey?: boolean;
+  /** API mode detected from Hermes config file */
+  detectedApiMode?: string;
   /** Model name to infer from if no explicit/detected provider */
   model?: string;
 }): { provider: string; resolvedFrom: string } {
-  const { explicitProvider, detectedProvider, detectedModel, model } = options;
+  const {
+    explicitProvider,
+    detectedProvider,
+    detectedModel,
+    detectedBaseUrl,
+    detectedHasApiKey,
+    detectedApiMode,
+    model,
+  } = options;
 
   // 1. Explicit provider from adapterConfig — user override, always wins
   if (explicitProvider && (VALID_PROVIDERS as readonly string[]).includes(explicitProvider)) {
     return { provider: explicitProvider, resolvedFrom: "adapterConfig" };
   }
 
+  const supportedProviders = VALID_PROVIDERS as readonly string[];
+  const configMatchesRequestedModel =
+    !!detectedModel &&
+    !!model &&
+    detectedModel.toLowerCase() === model.toLowerCase();
+
   // 2. Provider from Hermes config file — but ONLY if the config model matches
   //    the requested model. Otherwise the config provider is for a different model
   //    and would cause exactly the kind of routing bug we're fixing.
   if (
-    detectedProvider &&
-    detectedModel &&
-    (VALID_PROVIDERS as readonly string[]).includes(detectedProvider) &&
-    // Config model matches requested model (exact or case-insensitive)
-    detectedModel.toLowerCase() === model?.toLowerCase()
+    configMatchesRequestedModel &&
+    !!detectedProvider &&
+    supportedProviders.includes(detectedProvider)
   ) {
     return { provider: detectedProvider, resolvedFrom: "hermesConfig" };
   }
 
-  // 3. Infer from model name prefix
+  const hasRuntimeSignals = !!detectedBaseUrl || !!detectedHasApiKey || !!detectedApiMode;
+
+  // 3a. Matching Hermes config with an unsupported provider (for example "custom")
+  //     should not fall through to model-name inference, because that can route to
+  //     the wrong provider entirely. Defer back to Hermes's own runtime resolution.
+  if (configMatchesRequestedModel && !!detectedProvider && !supportedProviders.includes(detectedProvider)) {
+    return {
+      provider: "auto",
+      resolvedFrom: `hermesConfigUnsupported:${detectedProvider}`,
+    };
+  }
+
+  // 3b. Matching Hermes config may omit provider entirely while still specifying
+  //     enough runtime information (base_url, api_key, api_mode) for Hermes itself.
+  //     In that case, also defer to Hermes instead of doing a wrong prefix inference.
+  if (configMatchesRequestedModel && !detectedProvider && hasRuntimeSignals) {
+    return {
+      provider: "auto",
+      resolvedFrom: "hermesConfigRuntime",
+    };
+  }
+
+  // 4. Infer from model name prefix
   if (model) {
     const inferred = inferProviderFromModel(model);
     if (inferred) {
@@ -166,6 +212,6 @@ export function resolveProvider(options: {
     }
   }
 
-  // 4. Let Hermes auto-detect
+  // 5. Let Hermes auto-detect
   return { provider: "auto", resolvedFrom: "auto" };
 }

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -351,6 +351,9 @@ export async function execute(
     explicitProvider,
     detectedProvider: detectedConfig?.provider,
     detectedModel: detectedConfig?.model,
+    detectedBaseUrl: detectedConfig?.baseUrl,
+    detectedHasApiKey: detectedConfig?.hasApiKey,
+    detectedApiMode: detectedConfig?.apiMode,
     model,
   });
 

--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -130,9 +130,9 @@ function checkModel(
   };
 }
 
-function checkApiKeys(
+async function checkApiKeys(
   config: Record<string, unknown>,
-): AdapterEnvironmentCheck | null {
+): Promise<AdapterEnvironmentCheck | null> {
   // The server resolves secret refs into config.env before calling testEnvironment,
   // so we check config.env first (adapter-configured secrets), then fall back to
   // process.env (server/host environment). This mirrors how the Claude adapter does it.
@@ -152,15 +152,6 @@ function checkApiKeys(
   const hasKimi = has("KIMI_API_KEY");
   const hasMiniMax = has("MINIMAX_API_KEY");
 
-  if (!hasAnthropic && !hasOpenRouter && !hasOpenAI && !hasZai && !hasKimi && !hasMiniMax) {
-    return {
-      level: "warn",
-      message: "No LLM API keys found in environment",
-      hint: "Set API keys in the agent's env secrets or ~/.hermes/.env. Hermes supports: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, ZAI_API_KEY, KIMI_API_KEY, MINIMAX_API_KEY",
-      code: "hermes_no_api_keys",
-    };
-  }
-
   const providers: string[] = [];
   if (hasAnthropic) providers.push("Anthropic");
   if (hasOpenRouter) providers.push("OpenRouter");
@@ -169,10 +160,56 @@ function checkApiKeys(
   if (hasKimi) providers.push("Kimi");
   if (hasMiniMax) providers.push("MiniMax");
 
+  if (providers.length > 0) {
+    return {
+      level: "info",
+      message: `API keys found: ${providers.join(", ")}`,
+      code: "hermes_api_keys_found",
+    };
+  }
+
+  const requestedModel = asString(config.model);
+
+  let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
+  try {
+    detectedConfig = await detectModel();
+  } catch {
+    // Non-fatal
+  }
+
+  const supportedProviders = VALID_PROVIDERS as readonly string[];
+  const modelMatchesRequested =
+    !!detectedConfig?.model &&
+    (!requestedModel || detectedConfig.model.toLowerCase() === requestedModel.toLowerCase());
+
+  const matchingHermesConfigApiKey =
+    !!detectedConfig?.hasApiKey &&
+    modelMatchesRequested;
+
+  if (matchingHermesConfigApiKey && detectedConfig) {
+    const providerLabel = detectedConfig.provider || "auto";
+    if (!supportedProviders.includes(providerLabel)) {
+      return {
+        level: "info",
+        message: `Hermes config includes runtime settings for unsupported adapter provider "${providerLabel}" via ~/.hermes/config.yaml`,
+        hint: "Skipping the built-in API-key warning because Hermes can resolve this provider at runtime.",
+        code: "hermes_custom_provider_config",
+      };
+    }
+
+    return {
+      level: "info",
+      message: `Hermes config includes an API key for provider "${providerLabel}" via ~/.hermes/config.yaml`,
+      hint: "Skipping the built-in API-key warning because Hermes can use model.api_key from the local Hermes config.",
+      code: "hermes_api_key_in_config",
+    };
+  }
+
   return {
-    level: "info",
-    message: `API keys found: ${providers.join(", ")}`,
-    code: "hermes_api_keys_found",
+    level: "warn",
+    message: "No LLM API keys found in environment",
+    hint: "Set API keys in the agent's env secrets or ~/.hermes/.env. Hermes supports: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, ZAI_API_KEY, KIMI_API_KEY, MINIMAX_API_KEY",
+    code: "hermes_no_api_keys",
   };
 }
 
@@ -200,6 +237,9 @@ async function checkProviderConsistency(
     explicitProvider,
     detectedProvider: detectedConfig?.provider,
     detectedModel: detectedConfig?.model,
+    detectedBaseUrl: detectedConfig?.baseUrl,
+    detectedHasApiKey: detectedConfig?.hasApiKey,
+    detectedApiMode: detectedConfig?.apiMode,
     model,
   });
 
@@ -211,6 +251,29 @@ async function checkProviderConsistency(
       message: `Provider mismatch: adapterConfig has "${explicitProvider}" but ~/.hermes/config.yaml has "${detectedConfig.provider}". Using adapterConfig value.`,
       hint: `Model "${model}" may not work correctly with provider "${explicitProvider}". Consider aligning with your Hermes config or removing the explicit provider to use auto-detection.`,
       code: "hermes_provider_mismatch",
+    };
+  }
+
+  // If Hermes config matches the requested model but uses an adapter-unsupported
+  // provider such as "custom", do not report a false provider inference.
+  if (!explicitProvider && resolvedFrom.startsWith("hermesConfigUnsupported:")) {
+    const unsupportedProvider = resolvedFrom.split(":", 2)[1] || detectedConfig?.provider || "unknown";
+    return {
+      level: "info",
+      message: `Hermes config uses unsupported adapter provider "${unsupportedProvider}" for model "${model}" — deferring to Hermes auto-detection`,
+      hint: "Paperclip will avoid model-name provider inference here and let Hermes resolve the provider from ~/.hermes/config.yaml at runtime.",
+      code: "hermes_provider_unsupported",
+    };
+  }
+
+  // If matching Hermes config provides runtime signals without an explicit provider,
+  // also defer to Hermes rather than inventing a provider from the model name.
+  if (!explicitProvider && resolvedFrom === "hermesConfigRuntime") {
+    return {
+      level: "info",
+      message: `Hermes config provides runtime settings for model "${model}" without an explicit adapter provider — deferring to Hermes auto-detection`,
+      hint: "Paperclip will avoid model-name provider inference here and let Hermes resolve the provider from ~/.hermes/config.yaml at runtime.",
+      code: "hermes_provider_runtime_config",
     };
   }
 
@@ -274,7 +337,7 @@ export async function testEnvironment(
   if (modelCheck) checks.push(modelCheck);
 
   // 5. API keys (check config.env — server resolves secrets before calling us)
-  const apiKeyCheck = checkApiKeys(config);
+  const apiKeyCheck = await checkApiKeys(config);
   if (apiKeyCheck) checks.push(apiKeyCheck);
 
   // 6. Provider/model consistency

--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -132,6 +132,7 @@ function checkModel(
 
 async function checkApiKeys(
   config: Record<string, unknown>,
+  detectedConfig: Awaited<ReturnType<typeof detectModel>> | null,
 ): Promise<AdapterEnvironmentCheck | null> {
   // The server resolves secret refs into config.env before calling testEnvironment,
   // so we check config.env first (adapter-configured secrets), then fall back to
@@ -170,13 +171,6 @@ async function checkApiKeys(
 
   const requestedModel = asString(config.model);
 
-  let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
-  try {
-    detectedConfig = await detectModel();
-  } catch {
-    // Non-fatal
-  }
-
   const supportedProviders = VALID_PROVIDERS as readonly string[];
   const modelMatchesRequested =
     !!detectedConfig?.model &&
@@ -187,7 +181,17 @@ async function checkApiKeys(
     modelMatchesRequested;
 
   if (matchingHermesConfigApiKey && detectedConfig) {
-    const providerLabel = detectedConfig.provider || "auto";
+    const providerLabel = detectedConfig.provider.trim();
+
+    if (!providerLabel) {
+      return {
+        level: "info",
+        message: "Hermes config includes an API key for the requested model via ~/.hermes/config.yaml without an explicit provider",
+        hint: "Skipping the built-in API-key warning because Hermes can use model.api_key from the local Hermes config.",
+        code: "hermes_api_key_in_config",
+      };
+    }
+
     if (!supportedProviders.includes(providerLabel)) {
       return {
         level: "info",
@@ -219,19 +223,12 @@ async function checkApiKeys(
  */
 async function checkProviderConsistency(
   config: Record<string, unknown>,
+  detectedConfig: Awaited<ReturnType<typeof detectModel>> | null,
 ): Promise<AdapterEnvironmentCheck | null> {
   const model = asString(config.model);
   if (!model) return null;
 
   const explicitProvider = asString(config.provider);
-
-  // Try to detect from Hermes config
-  let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
-  try {
-    detectedConfig = await detectModel();
-  } catch {
-    // Non-fatal
-  }
 
   const { provider: resolved, resolvedFrom } = resolveProvider({
     explicitProvider,
@@ -336,12 +333,20 @@ export async function testEnvironment(
   const modelCheck = checkModel(config);
   if (modelCheck) checks.push(modelCheck);
 
-  // 5. API keys (check config.env — server resolves secrets before calling us)
-  const apiKeyCheck = await checkApiKeys(config);
+  // 5. Detect Hermes config once for the remaining checks.
+  let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
+  try {
+    detectedConfig = await detectModel();
+  } catch {
+    // Non-fatal
+  }
+
+  // 6. API keys (check config.env — server resolves secrets before calling us)
+  const apiKeyCheck = await checkApiKeys(config, detectedConfig);
   if (apiKeyCheck) checks.push(apiKeyCheck);
 
-  // 6. Provider/model consistency
-  const providerCheck = await checkProviderConsistency(config);
+  // 7. Provider/model consistency
+  const providerCheck = await checkProviderConsistency(config, detectedConfig);
   if (providerCheck) checks.push(providerCheck);
 
   // Determine overall status

--- a/tests/custom-provider.test.mjs
+++ b/tests/custom-provider.test.mjs
@@ -73,19 +73,29 @@ async function withHermesHomeConfig(configLines, fn) {
   const tempHome = await mkdtemp(join(tmpdir(), 'hermes-paperclip-adapter-'));
   const hermesDir = join(tempHome, '.hermes');
   const configPath = join(hermesDir, 'config.yaml');
-  const previousHome = process.env.HOME;
+  const previousEnv = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    HOMEDRIVE: process.env.HOMEDRIVE,
+    HOMEPATH: process.env.HOMEPATH,
+  };
 
   await mkdir(hermesDir, { recursive: true });
   await writeFile(configPath, `${configLines.join('\n')}\n`, 'utf8');
   process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  delete process.env.HOMEDRIVE;
+  delete process.env.HOMEPATH;
 
   try {
     return await fn();
   } finally {
-    if (previousHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = previousHome;
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
     await rm(tempHome, { recursive: true, force: true });
   }
@@ -109,6 +119,27 @@ test('testEnvironment does not warn about missing API keys when Hermes config pr
 
     assert.equal(codes.includes('hermes_no_api_keys'), false, JSON.stringify(result.checks, null, 2));
     assert.equal(result.status, 'pass', JSON.stringify(result.checks, null, 2));
+  });
+});
+
+test('testEnvironment describes provider-omitted runtime config without inventing provider "auto"', async () => {
+  await withHermesHomeConfig([
+    'model:',
+    '  default: oca/gpt-5.4',
+    '  base_url: https://example.invalid/litellm',
+    '  api_key: test-secret',
+  ], async () => {
+    const result = await testEnvironment({
+      config: {
+        hermesCommand: 'python3',
+        model: 'oca/gpt-5.4',
+      },
+    });
+
+    const apiKeyCheck = result.checks.find((check) => check.code === 'hermes_api_key_in_config');
+    assert.ok(apiKeyCheck, JSON.stringify(result.checks, null, 2));
+    assert.match(apiKeyCheck.message, /without an explicit provider/i);
+    assert.doesNotMatch(apiKeyCheck.message, /provider "auto"/i);
   });
 });
 

--- a/tests/custom-provider.test.mjs
+++ b/tests/custom-provider.test.mjs
@@ -1,0 +1,135 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { parseModelFromConfig, resolveProvider, testEnvironment } from '../dist/server/index.js';
+
+test('parseModelFromConfig tracks api_key presence without exposing the raw secret', () => {
+  const parsed = parseModelFromConfig([
+    'model:',
+    '  default: oca/gpt-5.4',
+    '  provider: custom',
+    '  base_url: https://example.invalid/litellm',
+    '  api_key: super-secret-value',
+    '',
+  ].join('\n'));
+
+  assert.ok(parsed);
+  assert.equal(parsed.hasApiKey, true);
+  assert.equal(Object.hasOwn(parsed, 'apiKey'), false);
+});
+
+test('resolveProvider does not fall through to model inference when Hermes config provider is unsupported but matches the requested model', () => {
+  const result = resolveProvider({
+    explicitProvider: undefined,
+    detectedProvider: 'custom',
+    detectedModel: 'oca/gpt-5.4',
+    detectedBaseUrl: 'https://example.invalid/litellm',
+    detectedHasApiKey: true,
+    model: 'oca/gpt-5.4',
+  });
+
+  assert.deepEqual(result, {
+    provider: 'auto',
+    resolvedFrom: 'hermesConfigUnsupported:custom',
+  });
+});
+
+test('resolveProvider also defers to Hermes runtime when the matching config omits provider but includes runtime signals', () => {
+  const result = resolveProvider({
+    explicitProvider: undefined,
+    detectedProvider: '',
+    detectedModel: 'oca/gpt-5.4',
+    detectedBaseUrl: 'https://example.invalid/litellm',
+    detectedHasApiKey: true,
+    model: 'oca/gpt-5.4',
+  });
+
+  assert.deepEqual(result, {
+    provider: 'auto',
+    resolvedFrom: 'hermesConfigRuntime',
+  });
+});
+
+test('resolveProvider still infers from the requested model when Hermes config is for a different model', () => {
+  const result = resolveProvider({
+    explicitProvider: undefined,
+    detectedProvider: 'custom',
+    detectedModel: 'oca/gpt-5.4',
+    detectedBaseUrl: 'https://example.invalid/litellm',
+    detectedHasApiKey: true,
+    model: 'claude-sonnet-4',
+  });
+
+  assert.deepEqual(result, {
+    provider: 'anthropic',
+    resolvedFrom: 'modelInference',
+  });
+});
+
+async function withHermesHomeConfig(configLines, fn) {
+  const tempHome = await mkdtemp(join(tmpdir(), 'hermes-paperclip-adapter-'));
+  const hermesDir = join(tempHome, '.hermes');
+  const configPath = join(hermesDir, 'config.yaml');
+  const previousHome = process.env.HOME;
+
+  await mkdir(hermesDir, { recursive: true });
+  await writeFile(configPath, `${configLines.join('\n')}\n`, 'utf8');
+  process.env.HOME = tempHome;
+
+  try {
+    return await fn();
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    await rm(tempHome, { recursive: true, force: true });
+  }
+}
+
+test('testEnvironment does not warn about missing API keys when Hermes config provides a supported provider api_key', async () => {
+  await withHermesHomeConfig([
+    'model:',
+    '  default: openrouter/gpt-4.1-mini',
+    '  provider: openrouter',
+    '  api_key: test-secret',
+  ], async () => {
+    const result = await testEnvironment({
+      config: {
+        hermesCommand: 'python3',
+        model: 'openrouter/gpt-4.1-mini',
+      },
+    });
+
+    const codes = result.checks.map((check) => check.code);
+
+    assert.equal(codes.includes('hermes_no_api_keys'), false, JSON.stringify(result.checks, null, 2));
+    assert.equal(result.status, 'pass', JSON.stringify(result.checks, null, 2));
+  });
+});
+
+test('testEnvironment does not warn about missing API keys when Hermes config provides a custom provider base_url and api_key', async () => {
+  await withHermesHomeConfig([
+    'model:',
+    '  default: oca/gpt-5.4',
+    '  provider: custom',
+    '  base_url: https://example.invalid/litellm',
+    '  api_key: test-secret',
+  ], async () => {
+    const result = await testEnvironment({
+      config: {
+        hermesCommand: 'python3',
+        model: 'oca/gpt-5.4',
+      },
+    });
+
+    const codes = result.checks.map((check) => check.code);
+
+    assert.equal(codes.includes('hermes_no_api_keys'), false, JSON.stringify(result.checks, null, 2));
+    assert.equal(result.status, 'pass', JSON.stringify(result.checks, null, 2));
+  });
+});


### PR DESCRIPTION
## Summary

- stop forcing model-name provider inference when a matching `~/.hermes/config.yaml` entry uses runtime config the adapter cannot safely represent
- suppress false `hermes_no_api_keys` warnings when the matching Hermes config already includes `model.api_key`
- add regression tests for supported-provider, unsupported-provider, and provider-omitted runtime config paths

## Test Plan

- `npm run test`
- `npm run typecheck`

## Maintenance Status

- Current head: `f9bb2829d5d881fe98e15b1034b4b53505055c5d`
- Mergeability: clean/mergeable against current `main`
- Review threads: no unresolved threads found in the latest maintenance check