### PR TITLE
feat: add listModels() to probe custom provider /v1/models endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,10 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
   for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
     const url = (block.match(/base_url:\s*(\S+)/) ?? block.match(/url:\s*(\S+)/))?.[1]?.trim();
     const key = block.match(/api_key:\s*(\S+)/)?.[1]?.trim() ?? "";
-    if (url && !endpoints.has(url)) endpoints.set(url, key);
+    if (url) {
+      // Add URL, or upgrade an existing keyless entry with a key we now have
+      if (!endpoints.has(url) || (!endpoints.get(url) && key)) endpoints.set(url, key);
+    }
   }
 
   // providers: map of name -> {api, api_key, default_model}
@@ -92,7 +95,7 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
   for (let i = 0; i < apiMatches.length; i++) {
     const url = apiMatches[i]?.[1]?.trim();
     const key = keyMatches[i]?.[1]?.trim() ?? "";
-    if (url && !endpoints.has(url)) endpoints.set(url, key);
+    if (url && (!endpoints.has(url) || (!endpoints.get(url) && key))) endpoints.set(url, key);
   }
 
   if (endpoints.size === 0) return [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@
  * @packageDocumentation
  */
 
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import { ADAPTER_TYPE, ADAPTER_LABEL } from "./shared/constants.js";
 
 export const type = ADAPTER_TYPE;
@@ -22,6 +25,94 @@ export const label = ADAPTER_LABEL;
  * since Hermes availability depends on the user's local configuration.
  */
 export const models: { id: string; label: string }[] = [];
+
+/**
+ * Probe an OpenAI-compatible /v1/models endpoint and return sorted model entries.
+ * Returns an empty array on any error so callers can fall back gracefully.
+ */
+async function fetchOpenAIModels(
+  baseUrl: string,
+  apiKey: string,
+): Promise<{ id: string; label: string }[]> {
+  try {
+    const url = baseUrl.replace(/\/$/, "") + "/models";
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { data?: unknown[] };
+    const items = Array.isArray(data?.data) ? data.data : [];
+    return (items as { id?: string }[])
+      .filter((m) => typeof m?.id === "string")
+      .map((m) => ({ id: m.id as string, label: m.id as string }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List all models available from the user's Hermes config.
+ *
+ * Reads `~/.hermes/config.yaml` (or `$HERMES_HOME/config.yaml`), extracts
+ * unique `base_url` + `api_key` pairs from the `custom_providers` list and
+ * `providers` map, probes each endpoint's `/v1/models` in parallel, and
+ * returns the deduplicated, sorted result.
+ *
+ * Falls back gracefully to an empty list if the config is missing or any
+ * endpoint is unreachable.
+ */
+export async function listModels(): Promise<{ id: string; label: string }[]> {
+  const hermesHome = process.env["HERMES_HOME"] ?? join(homedir(), ".hermes");
+  const configPath = join(hermesHome, "config.yaml");
+  let content: string;
+  try {
+    content = await readFile(configPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  // Extract unique (base_url, api_key) pairs via lightweight regex parsing.
+  // Covers both the `custom_providers:` list and the `providers:` map.
+  const endpoints = new Map<string, string>(); // url -> api_key
+
+  // custom_providers: list of {name, base_url, model, api_key?}
+  const cpSection =
+    content.match(/^custom_providers:\s*\n((?:[ \t]+-[^\n]*\n(?:[ \t][^\n]*\n)*)*)/m)?.[1] ?? "";
+  for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
+    const url = (block.match(/base_url:\s*(\S+)/) ?? block.match(/url:\s*(\S+)/))?.[1]?.trim();
+    const key = block.match(/api_key:\s*(\S+)/)?.[1]?.trim() ?? "";
+    if (url && !endpoints.has(url)) endpoints.set(url, key);
+  }
+
+  // providers: map of name -> {api, api_key, default_model}
+  const provSection = content.match(/^providers:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
+  const apiMatches = [...provSection.matchAll(/^\s+api:\s*(\S+)/gm)];
+  const keyMatches = [...provSection.matchAll(/^\s+api_key:\s*(\S+)/gm)];
+  for (let i = 0; i < apiMatches.length; i++) {
+    const url = apiMatches[i]?.[1]?.trim();
+    const key = keyMatches[i]?.[1]?.trim() ?? "";
+    if (url && !endpoints.has(url)) endpoints.set(url, key);
+  }
+
+  if (endpoints.size === 0) return [];
+
+  const fetched = await Promise.all(
+    [...endpoints.entries()].map(([url, key]) => fetchOpenAIModels(url, key)),
+  );
+
+  const seen = new Set<string>();
+  const results: { id: string; label: string }[] = [];
+  for (const batch of fetched) {
+    for (const m of batch) {
+      if (!seen.has(m.id)) {
+        seen.add(m.id);
+        results.push(m);
+      }
+    }
+  }
+  return results.sort((a, b) => a.id.localeCompare(b.id));
+}
 
 /**
  * Documentation shown in the Paperclip UI when configuring a Hermes agent.

--- a/src/server/detect-model.ts
+++ b/src/server/detect-model.ts
@@ -32,7 +32,7 @@ export interface DetectedModel {
 export async function detectModel(
   configPath?: string,
 ): Promise<DetectedModel | null> {
-  const filePath = configPath ?? join(homedir(), ".hermes", "config.yaml");
+  const filePath = configPath ?? join(process.env["HERMES_HOME"] ?? join(homedir(), ".hermes"), "config.yaml");
 
   let content: string;
   try {


### PR DESCRIPTION
## Summary

- Adds a `listModels()` export to the adapter index
- Reads `~/.hermes/config.yaml` (or `$HERMES_HOME/config.yaml`) and extracts unique `base_url` + `api_key` pairs from the `custom_providers` list and `providers` map
- Probes each endpoint's `/v1/models` in parallel (5s timeout per endpoint)
- Returns a deduplicated, sorted list of `{ id, label }` entries
- Falls back to `[]` if the config is missing or any endpoint is unreachable

## Motivation

Users who configure Hermes with custom/local providers (e.g. LiteLLM, Ollama, vLLM) see an empty model picker in the Paperclip UI because `models = []` and `listModels` was not implemented. This change populates the picker dynamically from the user's actual provider config.

## Test plan

- [ ] With `custom_providers` or `providers` entries pointing to a live OpenAI-compatible endpoint, `listModels()` returns all available models
- [ ] With no config file or unreachable endpoints, `listModels()` returns `[]` without throwing
- [ ] Multiple entries sharing the same `base_url` are deduped (only one probe request sent)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)