### PR TITLE
feat: make --yolo opt-out via adapterConfig.yolo (default true)

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -325,6 +325,10 @@ export async function execute(
   const persistSession = cfgBoolean(config.persistSession) !== false;
   const worktreeMode = cfgBoolean(config.worktreeMode) === true;
   const checkpoints = cfgBoolean(config.checkpoints) === true;
+  // Yolo mode (bypass approval prompts) defaults to true — see comment
+  // above args.push("--yolo") below for the rationale. Operators can
+  // opt out by setting adapterConfig.yolo = false.
+  const yolo = cfgBoolean(config.yolo) !== false;
 
   // ── Resolve provider (defense in depth) ────────────────────────────────
   // Priority chain:
@@ -394,7 +398,8 @@ export async function execute(
   // so approval prompts would always timeout and deny legitimate commands
   // (curl, python3 -c, etc.). Agents operate in a sandbox — the approval
   // system is designed for human-attended interactive sessions.
-  args.push("--yolo");
+  // Defaults to true; operators can opt out with adapterConfig.yolo = false.
+  if (yolo) args.push("--yolo");
 
   // Session resume
   const prevSessionId = cfgString(


### PR DESCRIPTION
## Summary

Currently `execute.ts` unconditionally appends `--yolo` to every `hermes chat` invocation. This PR preserves that default behavior but makes it configurable, so operators can opt out by setting `adapterConfig.yolo = false` on an agent.

## Motivation

Most Paperclip agents run as non-interactive subprocesses with no TTY, so `--yolo` is the right default (rationale already documented in the existing code comment). But there's no escape hatch today for environments where an operator wants Hermes's interactive approval prompts back — e.g. supervised / sandboxed runs, policy-restricted deployments, or debugging.

## Behavior

- **No change for existing users.** `config.yolo` is unset → defaults to `true` → `--yolo` is still appended. Exactly the same behavior as today.
- **New opt-out path.** Operators can set `adapterConfig.yolo = false` (via API or future UI field) to suppress `--yolo`.

Mirrors the pattern already used for `persistSession` (default `true` unless explicitly `false`).

## Test plan

- [x] `npm run build` — passes
- [x] `npm run typecheck` — passes
- [ ] Manual: agent with `yolo: false` in adapterConfig — verify `--yolo` is NOT in the spawned argv
- [ ] Manual: default agent (no `yolo` field) — verify `--yolo` IS in the spawned argv (unchanged behavior)

Related: paperclip issue [#2145](https://github.com/paperclipai/paperclip/issues/2145) (dangerously-skip-permissions for claude_local — same family of "agents can't answer approval prompts" problem).