### PR TITLE
Fix #52: show correct tools info

### DIFF
--- a/src/ui/parse-stdout.ts
+++ b/src/ui/parse-stdout.ts
@@ -218,6 +218,10 @@ export function parseHermesStdoutLine(
 
   // ── Quiet-mode tool/message lines (prefixed with ┊) ────────────────────
   if (trimmed.includes(TOOL_OUTPUT_PREFIX)) {
+    // Skip tool generation start lines (e.g., "preparing terminal...")
+    if (trimmed.includes("preparing")) {
+      return [];
+    }
     // Assistant message: ┊ 💬 {text}
     if (isAssistantToolLine(trimmed)) {
       return [{ kind: "assistant", ts, text: extractAssistantText(trimmed) }];


### PR DESCRIPTION
Fixes #52

Skip tool generation start lines that show "preparing terminal..." so that only actual tool completion lines generate tool cards with correct input and result.