### PR TITLE
Fix shell quoting in heartbeat wake prompt to prevent TypeError

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -108,7 +108,7 @@ Address the comment, POST a reply if needed, then continue working.
 ## Heartbeat Wake — Check for Work
 
 1. List ALL open issues assigned to you (todo, backlog, in_progress):
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
+   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f\\"{i['identifier']} {i['status']:>12} {i['priority']:>6} {i['title']}\\") for i in issues if i['status'] not in ('done','cancelled')]" \`
 
 2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
    - Read the issue details: \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
@@ -116,7 +116,7 @@ Address the comment, POST a reply if needed, then continue working.
    - When done, mark complete and post a comment (see Workflow steps 2-4 above)
 
 3. If no issues assigned to you, check for unassigned issues:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
+   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f\\"{i['identifier']} {i['title']}\\") for i in issues if not i.get('assigneeAgentId')]" \`
    If you find a relevant issue, assign it to yourself:
    \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
 


### PR DESCRIPTION
## Summary

Fix a shell-quoting bug in the heartbeat wake prompt that causes the
embedded `python3 -c "..."` one-liners to fail. Two-line change in
`src/server/execute.ts`.

## Problem

Both one-liners (assigned-issues listing and backlog listing) embed
a Python f-string whose dict keys use unescaped double quotes:

```bash
python3 -c "...[print(f'{i["identifier"]} {i["status"]:>12} ...}') ...]"
                    ^------- closes the shell -c string here
```

The inner `"` characters terminate the shell's outer double-quoted
`-c` arg. Bash splits the remainder into extra shell words and
Python receives a truncated script, producing failures like:

- `TypeError: string indices must be integers, not 'str'`
- `NameError: name 'identifier' is not defined`

When the issues list is empty, the mangled pipeline can exit 0 with
no output, silently masking the bug. Agents consistently report "no
work" even when real issues exist.

Observed in production on `hermes-paperclip-adapter@0.2.1` /
`paperclipai@2026.416.0` across multiple heartbeat invocations.

## Fix

For each of the two affected lines: switch the f-string to
double-quoted form with single-quoted dict keys, and shell-escape
the outer quotes (`\\"` in the TS source → literal `\"` in the
rendered prompt):

```diff
- [print(f'{i[\"identifier\"]} {i[\"status\"]:>12} ...}') for i in issues ...]
+ [print(f\\"{i['identifier']} {i['status']:>12} ...}\\") for i in issues ...]
```

The rendered prompt the LLM receives now contains:

```
python3 -c "...[print(f\"{i['identifier']} ...}\") for i in issues ...]"
```

which parses as a single shell word and a valid Python expression.

## Verification

Reproduced both states end-to-end by rendering the template and
piping a test payload through `bash | python3`:

```bash
# Before
$ echo '[{"identifier":"TRA-1","status":"todo","priority":"P1","title":"Hi"}]' \
  | python3 -c "...[print(f'{i[\"identifier\"]} {i[\"status\"]}') for i in issues if ...]"
NameError: name 'identifier' is not defined

# After
$ echo '[{"identifier":"TRA-1","status":"todo","priority":"P1","title":"Hi"},
         {"identifier":"TRA-2","status":"done","priority":"P2","title":"Bye"},
         {"identifier":"TRA-3","status":"in_progress","priority":"P0","title":"Urgent"}]' \
  | python3 -c "...[print(f\"{i['identifier']} {i['status']:>12} {i['priority']:>6} {i['title']}\") for i in issues if i['status'] not in ('done','cancelled')]"
TRA-1         todo     P1 Hi
TRA-3  in_progress     P0 Urgent
```

`npm run typecheck` and `npm run build` both pass.

## Risk / Compat

- String-content change inside a template literal only. No API surface change.
- User-provided `promptTemplate` overrides are unaffected (they already
  bypass the default).
- Output format is identical on success; the bug-hit paths previously
  failed or emitted nothing, so no existing correct behavior is altered.
