### PR TITLE
5ed6fac9-9535-4a88-a97f-14a9f9e0e641: Fix QA taskId interpolation in adapter promptTemplate

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -129,11 +129,11 @@ function buildPrompt(
 ): string {
   const template = cfgString(config.promptTemplate) || DEFAULT_PROMPT_TEMPLATE;
 
-  const taskId = cfgString(ctx.config?.taskId);
-  const taskTitle = cfgString(ctx.config?.taskTitle) || "";
-  const taskBody = cfgString(ctx.config?.taskBody) || "";
-  const commentId = cfgString(ctx.config?.commentId) || "";
-  const wakeReason = cfgString(ctx.config?.wakeReason) || "";
+  const taskId = cfgString(ctx.context?.taskId ?? ctx.context?.issueId ?? ctx.config?.taskId);
+  const taskTitle = cfgString(ctx.context?.taskTitle ?? ctx.config?.taskTitle) || "";
+  const taskBody = cfgString(ctx.context?.taskBody ?? ctx.config?.taskBody) || "";
+  const commentId = cfgString(ctx.context?.commentId ?? ctx.config?.commentId) || "";
+  const wakeReason = cfgString(ctx.context?.wakeReason ?? ctx.config?.wakeReason) || "";
   const agentName = ctx.agent?.name || "Hermes Agent";
   const companyName = cfgString(ctx.config?.companyName) || "";
   const projectName = cfgString(ctx.config?.projectName) || "";


### PR DESCRIPTION
## Changes

The Hermes Paperclip adapter buildPrompt() was reading taskId from ctx.config.taskId, which is only populated for assignment-triggered wakes (via the promptTemplate field in agent config). For QA-style wakes that pass task context via ctx.context, taskId was never read, so {{taskId}} stayed as a literal placeholder in curl URLs.

**Fix:** Changed buildPrompt() to read all context fields (taskId, taskTitle, taskBody, commentId, wakeReason) from ctx.context with fallback to ctx.config — matching the deployed dist/ behavior.

**Files changed:** 1 (src/server/execute.ts — 5 lines)

**Testing:** npm run build passes. No code behavior changes for dev-template agents (which already had correct context propagation).

Closes 5ed6fac9-9535-4a88-a97f-14a9f9e0e641