### PR TITLE
fix(server): forward ctx.onSpawn to runChildProcess

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -476,6 +476,7 @@ export async function execute(
     timeoutSec,
     graceSec,
     onLog: wrappedOnLog,
+    onSpawn: ctx.onSpawn,
   });
 
   // ── Parse output ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Paperclip's heartbeat passes `onSpawn` on `AdapterExecutionContext` so the control plane can persist `processPid` / `processGroupId` / `processStartedAt` on `heartbeat_runs` (via `runChildProcess`'s spawn callback). First-party adapters (e.g. claude-local) already forward this; Hermes did not.

## Change
Pass `onSpawn: ctx.onSpawn` into the `runChildProcess` options in `src/server/execute.ts`.

## Impact
- Cancel-after-restart can fall back to DB-stored pid when the in-memory process map is empty.
- Clearer process-loss messages when pid metadata exists.

## Risk
Low: `onSpawn` is optional; unchanged behavior when undefined.

## Verification
`npx tsc --noEmit` passes locally.

Made with [Cursor](https://cursor.com)