### PR TITLE
Update API call method - curl blocked by tirith policies

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -69,7 +69,7 @@ function cfgStringArray(v: unknown): string[] | undefined {
 
 const DEFAULT_PROMPT_TEMPLATE = `You are "{{agentName}}", an AI agent employee in a Paperclip-managed company.
 
-IMPORTANT: Use \`terminal\` tool with \`curl\` for ALL Paperclip API calls (web_extract and browser cannot access localhost).
+IMPORTANT: Use \`execute_code\` tool with \`urllib\` for ALL Paperclip API calls instead of curl (web_extract and browser cannot access localhost, curl is blocked by tirith security policies).
 
 Your Paperclip identity:
   Agent ID: {{agentId}}
@@ -88,37 +88,125 @@ Title: {{taskTitle}}
 
 1. Work on the task using your tools
 2. When done, mark the issue as completed:
-   \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}" -H "Content-Type: application/json" -d '{"status":"done"}'\`
+   \`\`\`python
+   import urllib.request, json, os
+   req = urllib.request.Request(
+       "{{paperclipApiUrl}}/issues/{{taskId}}",
+       data=json.dumps({"status":"done"}).encode(),
+       headers={
+           "Content-Type": "application/json",
+           "Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"
+       },
+       method="PATCH"
+   )
+   urllib.request.urlopen(req)
+   \`\`\`
 3. Post a completion comment on the issue summarizing what you did:
-   \`curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments" -H "Content-Type: application/json" -d '{"body":"DONE: <your summary here>"}'\`
+   \`\`\`python
+   import urllib.request, json, os
+   req = urllib.request.Request(
+       "{{paperclipApiUrl}}/issues/{{taskId}}/comments",
+       data=json.dumps({"body":"DONE: <your summary here>"}).encode(),
+       headers={
+           "Content-Type": "application/json",
+           "Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"
+       },
+       method="POST"
+   )
+   urllib.request.urlopen(req)
+   \`\`\`
 4. If this issue has a parent (check the issue body or comments for references like TRA-XX), post a brief notification on the parent issue so the parent owner knows:
-   \`curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments" -H "Content-Type: application/json" -d '{"body":"{{agentName}} completed {{taskId}}. Summary: <brief>"}'\`
+   \`\`\`python
+   import urllib.request, json, os
+   req = urllib.request.Request(
+       "{{paperclipApiUrl}}/issues/PARENT_ISSUE_ID/comments",
+       data=json.dumps({"body":"{{agentName}} completed {{taskId}}. Summary: <brief>"}).encode(),
+       headers={
+           "Content-Type": "application/json",
+           "Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"
+       },
+       method="POST"
+   )
+   urllib.request.urlopen(req)
+   \`\`\`
 {{/taskId}}
 
 {{#commentId}}
 ## Comment on This Issue
 
 Someone commented. Read it:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}" | python3 -m json.tool\`
+   \`\`\`python
+   import urllib.request, json, os
+   req = urllib.request.Request(
+       "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}",
+       headers={"Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"}
+   )
+   with urllib.request.urlopen(req) as res:
+       data = json.loads(res.read())
+       print(json.dumps(data, indent=2))
+   \`\`\`
 
 Address the comment, POST a reply if needed, then continue working.
 {{/commentId}}
 
 {{#noTask}}
-## Heartbeat Wake — Check for Work
+## Heartbeat Wake - Check for Work
 
 1. List ALL open issues assigned to you (todo, backlog, in_progress):
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
+   \`\`\`python
+   import urllib.request, json, os
+   req = urllib.request.Request(
+       "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}",
+       headers={"Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"}
+   )
+   with urllib.request.urlopen(req) as res:
+       issues = json.loads(res.read())
+       for i in issues:
+           if i['status'] not in ('done','cancelled'):
+               print(f'{i["identifier"]} {i["status"]:>12} {i["priority"]:>6} {i["title"]}')
+   \`\`\`
 
 2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
-   - Read the issue details: \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
+   - Read the issue details:
+     \`\`\`python
+     import urllib.request, json, os
+     req = urllib.request.Request(
+         "{{paperclipApiUrl}}/issues/ISSUE_ID",
+         headers={"Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"}
+     )
+     with urllib.request.urlopen(req) as res:
+         print(json.dumps(json.loads(res.read()), indent=2))
+     \`\`\`
    - Do the work in the project directory: {{projectName}}
    - When done, mark complete and post a comment (see Workflow steps 2-4 above)
 
 3. If no issues assigned to you, check for unassigned issues:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
+   \`\`\`python
+   import urllib.request, json, os
+   req = urllib.request.Request(
+       "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog",
+       headers={"Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"}
+   )
+   with urllib.request.urlopen(req) as res:
+       issues = json.loads(res.read())
+       for i in issues:
+           if not i.get('assigneeAgentId'):
+               print(f'{i["identifier"]} {i["title"]}')
+   \`\`\`
    If you find a relevant issue, assign it to yourself:
-   \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
+   \`\`\`python
+   import urllib.request, json, os
+   req = urllib.request.Request(
+       "{{paperclipApiUrl}}/issues/ISSUE_ID",
+       data=json.dumps({"assigneeAgentId":"{{agentId}}","status":"todo"}).encode(),
+       headers={
+           "Content-Type": "application/json",
+           "Authorization": f"Bearer {os.environ['PAPERCLIP_API_KEY']}"
+       },
+       method="PATCH"
+   )
+   urllib.request.urlopen(req)
+   \`\`\`
 
 4. If truly nothing to do, report briefly what you checked.
 {{/noTask}}`;


### PR DESCRIPTION
Hermes Agent now ships with tirith security scanner which is blocking all curl calls to the Paperclip API. This is blocking regular health checks and scanning of issue tickets.

Several users have reported this issue in paperclipai/paperclip#3165

This fix instructs Hermes to use execute_code with urllib when working with the Paperclip API.