### PR TITLE
fix: use --quiet instead of -Q flag for Hermes CLI compatibility

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -1,12 +1,12 @@
 /**
  * Server-side execution logic for the Hermes Agent adapter.
  *
- * Spawns `hermes chat -q "..." -Q` as a child process, streams output,
+ * Spawns `hermes chat -q "..." --quiet` as a child process, streams output,
  * and returns structured results to Paperclip.
  *
  * Verified CLI flags (hermes chat):
  *   -q/--query         single query (non-interactive)
- *   -Q/--quiet         quiet mode (no banner/spinner, only response + session_id)
+ *   --quiet            quiet mode (no banner/spinner, only response + session_id)
  *   -m/--model         model name (e.g. anthropic/claude-sonnet-4)
  *   -t/--toolsets      comma-separated toolsets to enable
  *   --provider         inference provider (auto, openrouter, nous, etc.)
@@ -358,10 +358,12 @@ export async function execute(
   const prompt = buildPrompt(ctx, config);
 
   // ── Build command args ─────────────────────────────────────────────────
-  // Use -Q (quiet) to get clean output: just response + session_id line
+  // Use --quiet to get clean output: just response + session_id line
+  // Note: Hermes CLI (v0.10.0) does not support -Q as a shorthand.
+  // The --quiet flag must be passed in its long form.
   const useQuiet = cfgBoolean(config.quiet) !== false; // default true
   const args: string[] = ["chat", "-q", prompt];
-  if (useQuiet) args.push("-Q");
+  if (useQuiet) args.push("--quiet");
 
   if (model) {
     args.push("-m", model);


### PR DESCRIPTION
## Problem

The adapter spawns Hermes CLI with the `-Q` flag for quiet mode, but Hermes CLI (v0.10.0) does not support `-Q` as a shorthand for `--quiet`. This causes every heartbeat/execution to fail with:

```
ERROR: Could not consume arg: -Q
```

## Root Cause

Hermes CLI defines quiet mode with only the long form `--quiet` flag (no short alias):

```
--quiet=QUIET    Type: bool    Default: False
```

The adapter comment claimed `-Q/--quiet` was supported, but only `--quiet` is valid.

## Fix

Changed `args.push("-Q")` to `args.push("--quiet")` in `src/server/execute.ts`.

Also updated the JSDoc comment to reflect the correct flag syntax.

## Testing

- Verified Hermes CLI rejects `-Q` with error
- Verified `--quiet` works correctly with Hermes v0.10.0
- Confirmed no other references to `-Q` in the adapter codebase

## Files Changed

- `src/server/execute.ts`: Line 365 - changed `"-Q"` to `"--quiet"`, updated JSDoc comments