### PR TITLE
feat(adapter): add hermesHome config field for multi-instance isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Available toolsets: `terminal`, `file`, `web`, `browser`, `code_execution`, `vis
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `hermesCommand` | string | `hermes` | Custom CLI binary path |
+| `hermesHome` | string | `$HERMES_HOME` or `~/.hermes` | Hermes home directory override; sets `HERMES_HOME` env var on the spawned subprocess so config, state, sessions, and credentials are isolated per adapter instance |
 | `verbose` | boolean | `false` | Enable verbose output |
 | `quiet` | boolean | `true` | Quiet mode (clean output, no banner/spinner) |
 | `extraArgs` | string[] | `[]` | Additional CLI arguments |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ tools, persistent memory, session persistence, skills, and MCP support.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | hermesCommand | string | hermes | Path to hermes CLI binary |
+| hermesHome | string | $HERMES_HOME or ~/.hermes | Hermes home directory override; isolates config/state/sessions per instance |
 | verbose | boolean | false | Enable verbose output |
 | extraArgs | string[] | [] | Additional CLI arguments |
 | env | object | {} | Extra environment variables |

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -18,6 +18,9 @@
  *   --source           session source tag for filtering
  */
 
+import os from "os";
+import path from "path";
+
 import type {
   AdapterExecutionContext,
   AdapterExecutionResult,
@@ -316,6 +319,7 @@ export async function execute(
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
+  const hermesHome = cfgString(config.hermesHome);
   const model = cfgString(config.model) || DEFAULT_MODEL;
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
@@ -424,6 +428,9 @@ export async function execute(
   if (userEnv && typeof userEnv === "object") {
     Object.assign(env, userEnv);
   }
+
+  if (hermesHome) env.HERMES_HOME = hermesHome;
+  else if (!env.HERMES_HOME) env.HERMES_HOME = path.join(os.homedir(), ".hermes");
 
   // ── Resolve working directory ──────────────────────────────────────────
   const cwd =


### PR DESCRIPTION
## Summary

Adds an optional `hermesHome: string` field to the Hermes local adapter config. When set, the spawned Hermes subprocess receives `HERMES_HOME=<value>` in its environment, isolating config, state.db, sessions, and credentials per adapter instance.

Preserves existing behavior when unset: inherits `process.env.HERMES_HOME` if present, else falls back to `path.join(os.homedir(), '.hermes')`.

## Motivation

Running multiple Hermes instances on one host, each bound to a different LLM backend (Qwen, Kimi, GLM, etc.) with separate config.yaml, credential pool, and session history — all dispatched from the same Paperclip instance via the `hermes_local` adapter.

Today the adapter always targets the single `HERMES_HOME` inherited from the parent Paperclip process. That forces one Hermes-per-host, which caps per-provider concurrency (BigModel GLM is hard-limited to 1 call per API key) and couples role/backend choice to host topology.

With `hermesHome`, a single Paperclip can register multiple agents whose adapter configs point at `/root/.hermes-qwen`, `/root/.hermes-kimi`, `/root/.hermes-glm`, etc. Each agent gets its own Hermes instance with independent state.

## Changes

- **`src/server/execute.ts`**: import `os` + `path`; extract `cfgString(config.hermesHome)`; inject `HERMES_HOME` into child env after the `userEnv` merge with `os.homedir()` fallback.
- **`README.md`**: document the field in the Advanced config table.
- **`src/index.ts`**: mirror the documentation in `agentConfigurationDoc` (shown in Paperclip UI).

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes; compiled `dist/server/execute.js` contains the new field extraction and env injection
- [x] Single-instance non-regression: unset `hermesHome` → adapter resolves `HERMES_HOME` via existing precedence (parent env, then `~/.hermes`)
- [ ] Multi-instance smoke test: three Paperclip agents with distinct `hermesHome` values run in parallel against separate Hermes state directories (deferred to downstream integration)

## Related

Part of a three-agent-per-company rollout in the AIW AI Workforce framework. See the two-harness architecture page for context on how Hermes serves as the autonomous Paperclip-dispatched harness alongside Claude Code.