### PR TITLE
fix: preserve env-only Hermes providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Create issues in Paperclip and assign them to your Hermes agent. On each heartbe
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `model` | string | `anthropic/claude-sonnet-4` | Model in `provider/model` format |
-| `provider` | string | *(auto-detected)* | API provider: `auto`, `openrouter`, `nous`, `openai-codex`, `zai`, `kimi-coding`, `minimax`, `minimax-cn` |
+| `provider` | string | *(auto-detected)* | API provider: `auto`, `openrouter`, `nous`, `openai-codex`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `opencode-go`, etc. Explicit values in `adapterConfig.provider` take precedence over model-name inference. |
 | `timeoutSec` | number | `300` | Execution timeout in seconds |
 | `graceSec` | number | `10` | Grace period before SIGKILL |
 
@@ -132,6 +132,8 @@ Available toolsets: `terminal`, `file`, `web`, `browser`, `code_execution`, `vis
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `hermesCommand` | string | `hermes` | Custom CLI binary path |
+| `baseUrl` / `base_url` | string | *(unset)* | Base URL override for env-only providers such as `opencode-go`; exported to Hermes as `HERMES_BASE_URL`. |
+| `apiMode` / `api_mode` | string | *(unset)* | API mode override for env-only providers; exported as `HERMES_API_MODE`. |
 | `verbose` | boolean | `false` | Enable verbose output |
 | `quiet` | boolean | `true` | Quiet mode (clean output, no banner/spinner) |
 | `extraArgs` | string[] | `[]` | Additional CLI arguments |
@@ -163,6 +165,29 @@ Conditional sections:
 - `{{#taskId}}...{{/taskId}}` — included only when a task is assigned
 - `{{#noTask}}...{{/noTask}}` — included only when no task (heartbeat check)
 - `{{#commentId}}...{{/commentId}}` — included only when woken by a comment
+
+## Env-only provider example
+
+Some Hermes providers are configured through environment variables rather than
+`hermes chat --provider` choices. For example, OpenCode Go can be configured
+explicitly without being overwritten by Kimi/MiniMax model-name inference:
+
+```json
+{
+  "adapterType": "hermes_local",
+  "adapterConfig": {
+    "model": "kimi-k2.6",
+    "provider": "opencode-go",
+    "baseUrl": "https://opencode.ai/zen/go/v1",
+    "apiMode": "chat_completions"
+  }
+}
+```
+
+For `provider: "opencode-go"`, the adapter exports
+`HERMES_INFERENCE_PROVIDER`, `HERMES_MODEL`, `HERMES_BASE_URL`, and
+`HERMES_API_MODE` instead of passing an unsupported `--provider opencode-go`
+flag to the Hermes CLI.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test test/*.mjs",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ tools, persistent memory, session persistence, skills, and MCP support.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | model | string | (Hermes configured default) | Optional explicit model in provider/model format. Leave blank to use Hermes's configured default model. |
-| provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, zai, kimi-coding, minimax, minimax-cn. Usually not needed — Hermes auto-detects from model name. |
+| provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, zai, kimi-coding, kimi-coding-cn, minimax, minimax-cn, opencode-go. Explicit adapterConfig values take precedence over model-name inference. |
 | timeoutSec | number | 300 | Execution timeout in seconds |
 | graceSec | number | 10 | Grace period after SIGTERM before SIGKILL |
 
@@ -65,6 +65,8 @@ tools, persistent memory, session persistence, skills, and MCP support.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | hermesCommand | string | hermes | Path to hermes CLI binary |
+| baseUrl / base_url | string | (unset) | Base URL override for env-only providers such as opencode-go |
+| apiMode / api_mode | string | (unset) | API mode override for env-only providers |
 | verbose | boolean | false | Enable verbose output |
 | extraArgs | string[] | [] | Additional CLI arguments |
 | env | object | {} | Extra environment variables |

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -36,7 +36,7 @@ import {
   DEFAULT_TIMEOUT_SEC,
   DEFAULT_GRACE_SEC,
   DEFAULT_MODEL,
-  VALID_PROVIDERS,
+  CLI_FLAG_PROVIDERS,
 } from "../shared/constants.js";
 
 import {
@@ -317,6 +317,8 @@ export async function execute(
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
   const model = cfgString(config.model) || DEFAULT_MODEL;
+  const baseUrl = cfgString(config.baseUrl) || cfgString(config.base_url);
+  const apiMode = cfgString(config.apiMode) || cfgString(config.api_mode);
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
@@ -363,13 +365,17 @@ export async function execute(
   const args: string[] = ["chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 
-  if (model) {
+  const providerUsesCliFlag = (CLI_FLAG_PROVIDERS as readonly string[]).includes(resolvedProvider);
+
+  if (model && providerUsesCliFlag) {
     args.push("-m", model);
   }
 
-  // Always pass --provider when we have a resolved one (not "auto").
-  // "auto" means Hermes will decide on its own — no need to pass it.
-  if (resolvedProvider !== "auto") {
+  // Pass --provider only for providers accepted by Hermes's argparse choices.
+  // Env-only providers such as opencode-go are applied below through
+  // HERMES_INFERENCE_PROVIDER/HERMES_MODEL instead, otherwise Hermes exits
+  // before it can read the environment override.
+  if (resolvedProvider !== "auto" && providerUsesCliFlag) {
     args.push("--provider", resolvedProvider);
   }
 
@@ -423,6 +429,13 @@ export async function execute(
   const userEnv = config.env as Record<string, string> | undefined;
   if (userEnv && typeof userEnv === "object") {
     Object.assign(env, userEnv);
+  }
+
+  if (!providerUsesCliFlag && resolvedProvider !== "auto") {
+    env.HERMES_INFERENCE_PROVIDER = resolvedProvider;
+    if (model) env.HERMES_MODEL = model;
+    if (baseUrl) env.HERMES_BASE_URL = baseUrl;
+    if (apiMode) env.HERMES_API_MODE = apiMode;
   }
 
   // ── Resolve working directory ──────────────────────────────────────────

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -21,23 +21,46 @@ export const DEFAULT_GRACE_SEC = 10;
 export const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
 
 /**
- * Valid --provider choices for the hermes CLI.
+ * Provider names that can be passed directly to `hermes chat --provider`.
  * Must stay in sync with `hermes chat --help`.
  */
-export const VALID_PROVIDERS = [
+export const CLI_FLAG_PROVIDERS = [
   "auto",
   "openrouter",
   "nous",
   "openai-codex",
-  "copilot",
   "copilot-acp",
+  "copilot",
   "anthropic",
+  "gemini",
+  "xai",
+  "ollama-cloud",
   "huggingface",
   "zai",
   "kimi-coding",
+  "kimi-coding-cn",
+  "stepfun",
   "minimax",
   "minimax-cn",
   "kilocode",
+  "xiaomi",
+  "arcee",
+  "nvidia",
+] as const;
+
+/**
+ * Provider names accepted in adapterConfig but applied through Hermes env vars
+ * instead of `--provider` because the current Hermes CLI parser does not expose
+ * them as flag choices.
+ */
+export const ENV_ONLY_PROVIDERS = [
+  "opencode-go",
+] as const;
+
+/** Valid provider choices accepted by adapterConfig. */
+export const VALID_PROVIDERS = [
+  ...CLI_FLAG_PROVIDERS,
+  ...ENV_ONLY_PROVIDERS,
 ] as const;
 
 /**

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -37,8 +37,9 @@ export function buildHermesConfig(
   //   2. ~/.hermes/config.yaml detection
   //   3. Model-name prefix inference
   //   4. "auto" fallback
-  // This ensures correct provider routing even for agents created
-  // before provider tracking existed.
+  // Explicit providers such as opencode-go are preserved; env-only providers
+  // are exported through Hermes environment variables at runtime instead of
+  // being passed as unsupported CLI --provider choices.
 
   // Execution limits — let the user configure these from the Paperclip UI.
   // timeoutSec: wall-clock kill timeout for the hermes child process.

--- a/test/detect-model.test.mjs
+++ b/test/detect-model.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveProvider,
+} from '../dist/server/detect-model.js';
+import {
+  CLI_FLAG_PROVIDERS,
+  ENV_ONLY_PROVIDERS,
+  VALID_PROVIDERS,
+} from '../dist/shared/constants.js';
+
+test('explicit opencode-go provider wins over model-name inference', () => {
+  const resolved = resolveProvider({
+    explicitProvider: 'opencode-go',
+    model: 'kimi-k2.6',
+  });
+
+  assert.deepEqual(resolved, {
+    provider: 'opencode-go',
+    resolvedFrom: 'adapterConfig',
+  });
+});
+
+test('opencode-go is accepted as config provider but not passed as a Hermes CLI --provider flag', () => {
+  assert.equal(VALID_PROVIDERS.includes('opencode-go'), true);
+  assert.equal(ENV_ONLY_PROVIDERS.includes('opencode-go'), true);
+  assert.equal(CLI_FLAG_PROVIDERS.includes('opencode-go'), false);
+});


### PR DESCRIPTION
## Summary
- Preserve explicit adapterConfig.provider values such as opencode-go instead of falling back to model-name inference.
- Split Hermes providers into CLI-safe providers and env-only providers.
- For env-only providers, export HERMES_INFERENCE_PROVIDER, HERMES_MODEL, HERMES_BASE_URL, and HERMES_API_MODE instead of passing an unsupported --provider flag.
- Document the OpenCode Go adapterConfig pattern and add node:test coverage.

## Problem
Explicit OpenCode Go routing can be lost for models like kimi-k2.6 or minimax-m2.7 because opencode-go was not accepted as a valid provider. The adapter then inferred kimi-coding/minimax from the model name, which defeats explicit Paperclip adapterConfig routing.

## Test Plan
- npm test
- npm run typecheck