### PR TITLE
fix: pass global Hermes args before chat command

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -62,6 +62,47 @@ function cfgStringArray(v: unknown): string[] | undefined {
     ? (v as string[])
     : undefined;
 }
+function splitGlobalExtraArgs(v: unknown): {
+  preCommandArgs: string[];
+  postCommandArgs: string[];
+} {
+  if (!Array.isArray(v) || v.length === 0) {
+    return { preCommandArgs: [], postCommandArgs: [] };
+  }
+
+  const preCommandArgs: string[] = [];
+  const postCommandArgs: string[] = [];
+
+  for (let i = 0; i < v.length; i += 1) {
+    const arg = v[i];
+    if (typeof arg !== "string") continue;
+
+    const profilePairMatch = arg.match(/^(--profile|-p)\s+(.+)$/);
+    if (profilePairMatch) {
+      preCommandArgs.push(profilePairMatch[1], profilePairMatch[2].trim());
+      continue;
+    }
+
+    if (arg === "--profile" || arg === "-p") {
+      preCommandArgs.push(arg);
+      const next = v[i + 1];
+      if (typeof next === "string" && next.length > 0) {
+        preCommandArgs.push(next);
+        i += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith("--profile=") || arg.startsWith("-p=")) {
+      preCommandArgs.push(arg);
+      continue;
+    }
+
+    postCommandArgs.push(arg);
+  }
+
+  return { preCommandArgs, postCommandArgs };
+}
 
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
@@ -322,6 +363,7 @@ export async function execute(
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
   const extraArgs = cfgStringArray(config.extraArgs);
+  const { preCommandArgs, postCommandArgs } = splitGlobalExtraArgs(extraArgs);
   const persistSession = cfgBoolean(config.persistSession) !== false;
   const worktreeMode = cfgBoolean(config.worktreeMode) === true;
   const checkpoints = cfgBoolean(config.checkpoints) === true;
@@ -360,7 +402,7 @@ export async function execute(
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line
   const useQuiet = cfgBoolean(config.quiet) !== false; // default true
-  const args: string[] = ["chat", "-q", prompt];
+  const args: string[] = [...preCommandArgs, "chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 
   if (model) {
@@ -404,8 +446,8 @@ export async function execute(
     args.push("--resume", prevSessionId);
   }
 
-  if (extraArgs?.length) {
-    args.push(...extraArgs);
+  if (postCommandArgs.length) {
+    args.push(...postCommandArgs);
   }
 
   // ── Build environment ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pass global Hermes CLI arguments before the `chat` subcommand, while keeping command-specific arguments after `chat`.

## Why

Some Hermes CLI options are global options and must appear before the subcommand.

For example:

```bash
hermes --profile my-profile chat -q "..."
```

is valid, while:

```bash
hermes chat -q "..." --profile my-profile
```

can be parsed incorrectly because `--profile` belongs to the top-level Hermes command.

This matters when Paperclip agents need to run Hermes with a specific profile.

## Change

- split `extraArgs` into:
  - global pre-command args
  - post-command args
- move profile-style args before `chat`
- preserve existing behavior for non-global extra args

Supported profile forms include:

```text
--profile value
--profile=value
-p value
-p=value
```

## Validation

- `npm run typecheck`
- `npm run build`
