### PR TITLE
Route Grok models through xai provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ tools, persistent memory, session persistence, skills, and MCP support.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | model | string | (Hermes configured default) | Optional explicit model in provider/model format. Leave blank to use Hermes's configured default model. |
-| provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, zai, kimi-coding, minimax, minimax-cn. Usually not needed — Hermes auto-detects from model name. |
+| provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, xai, zai, kimi-coding, minimax, minimax-cn. Usually not needed — Hermes auto-detects from model name. |
 | timeoutSec | number | 300 | Execution timeout in seconds |
 | graceSec | number | 10 | Grace period after SIGTERM before SIGKILL |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ tools, persistent memory, session persistence, skills, and MCP support.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | model | string | (Hermes configured default) | Optional explicit model in provider/model format. Leave blank to use Hermes's configured default model. |
-| provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, xai, zai, kimi-coding, minimax, minimax-cn. Usually not needed — Hermes auto-detects from model name. |
+| provider | string | (auto) | Optional API provider override (for example: auto, openrouter, nous, openai-codex, xai, zai, kimi-coding, minimax, minimax-cn). Supported values depend on Hermes; see \`hermes chat --help\` for the current list. Usually not needed — Hermes auto-detects from model name. |
 | timeoutSec | number | 300 | Execution timeout in seconds |
 | graceSec | number | 10 | Grace period after SIGTERM before SIGKILL |
 

--- a/src/server/test.ts
+++ b/src/server/test.ts
@@ -148,15 +148,16 @@ function checkApiKeys(
   const hasAnthropic = has("ANTHROPIC_API_KEY");
   const hasOpenRouter = has("OPENROUTER_API_KEY");
   const hasOpenAI = has("OPENAI_API_KEY");
+  const hasXai = has("XAI_API_KEY");
   const hasZai = has("ZAI_API_KEY");
   const hasKimi = has("KIMI_API_KEY");
   const hasMiniMax = has("MINIMAX_API_KEY");
 
-  if (!hasAnthropic && !hasOpenRouter && !hasOpenAI && !hasZai && !hasKimi && !hasMiniMax) {
+  if (!hasAnthropic && !hasOpenRouter && !hasOpenAI && !hasXai && !hasZai && !hasKimi && !hasMiniMax) {
     return {
       level: "warn",
       message: "No LLM API keys found in environment",
-      hint: "Set API keys in the agent's env secrets or ~/.hermes/.env. Hermes supports: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, ZAI_API_KEY, KIMI_API_KEY, MINIMAX_API_KEY",
+      hint: "Set API keys in the agent's env secrets or ~/.hermes/.env. Hermes supports: ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, XAI_API_KEY, ZAI_API_KEY, KIMI_API_KEY, MINIMAX_API_KEY",
       code: "hermes_no_api_keys",
     };
   }
@@ -165,6 +166,7 @@ function checkApiKeys(
   if (hasAnthropic) providers.push("Anthropic");
   if (hasOpenRouter) providers.push("OpenRouter");
   if (hasOpenAI) providers.push("OpenAI");
+  if (hasXai) providers.push("xAI");
   if (hasZai) providers.push("Z.AI");
   if (hasKimi) providers.push("Kimi");
   if (hasMiniMax) providers.push("MiniMax");

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -32,6 +32,7 @@ export const VALID_PROVIDERS = [
   "copilot",
   "copilot-acp",
   "anthropic",
+  "xai",
   "huggingface",
   "zai",
   "kimi-coding",
@@ -59,6 +60,8 @@ export const MODEL_PREFIX_PROVIDER_HINTS: [string, string][] = [
   ["claude", "anthropic"],
   // Google models (via openrouter or direct)
   ["gemini", "auto"],
+  // xAI / Grok models
+  ["grok", "xai"],
   // Nous models
   ["hermes-", "nous"],
   // Z.AI / GLM models


### PR DESCRIPTION
Add xAI/Grok routing to the Hermes adapter provider resolver.

- Accept `xai` as a valid Hermes `--provider` value
- Infer Grok model names to `xai` instead of falling back to `auto`
- Recognize `XAI_API_KEY` in the adapter environment check

Verified with `npm run typecheck`, `git diff --check`, and a compiled resolver smoke check for `grok-4.20-0309-reasoning`.