### PR TITLE
List configured Hermes models when probes cannot authenticate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -62,6 +63,21 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "^2026.325.0",
-    "picocolors": "^1.1.0"
+    "picocolors": "^1.1.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ import { ADAPTER_TYPE, ADAPTER_LABEL } from "./shared/constants.js";
 export const type = ADAPTER_TYPE;
 export const label = ADAPTER_LABEL;
 
+type ModelEntry = { id: string; label: string };
+type ConfigRecord = Record<string, unknown>;
+
+const LIST_MODELS_CACHE_TTL_MS = 30_000;
+let listModelsCache: { expiresAt: number; models: ModelEntry[] } | null = null;
+
 /**
  * Models available through Hermes Agent.
  *
@@ -25,9 +31,7 @@ export const label = ADAPTER_LABEL;
  * prefer detectModel() plus manual entry over curated placeholder models,
  * since Hermes availability depends on the user's local configuration.
  */
-export const models: { id: string; label: string }[] = [];
-
-type ConfigRecord = Record<string, unknown>;
+export const models: ModelEntry[] = [];
 
 /**
  * Probe an OpenAI-compatible /v1/models endpoint and return sorted model entries.
@@ -36,7 +40,7 @@ type ConfigRecord = Record<string, unknown>;
 async function fetchOpenAIModels(
   baseUrl: string,
   apiKey: string,
-): Promise<{ id: string; label: string }[]> {
+): Promise<ModelEntry[]> {
   try {
     const url = baseUrl.replace(/\/$/, "") + "/models";
     const headers: Record<string, string> = { "Content-Type": "application/json" };
@@ -164,7 +168,10 @@ function collectEndpoints(config: ConfigRecord): Map<string, string> {
  * credentials that are not available to the Paperclip process or an endpoint is
  * unreachable.
  */
-export async function listModels(): Promise<{ id: string; label: string }[]> {
+export async function listModels(): Promise<ModelEntry[]> {
+  const now = Date.now();
+  if (listModelsCache && listModelsCache.expiresAt > now) return listModelsCache.models;
+
   const hermesHome = process.env["HERMES_HOME"]?.trim() || join(homedir(), ".hermes");
   const configPath = join(hermesHome, "config.yaml");
   let content: string;
@@ -189,9 +196,14 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
       if (!modelsById.has(m.id)) modelsById.set(m.id, m.label);
     }
   }
-  return [...modelsById.entries()]
+  const discovered = [...modelsById.entries()]
     .map(([id, label]) => ({ id, label }))
     .sort((a, b) => a.id.localeCompare(b.id));
+  listModelsCache = {
+    expiresAt: Date.now() + LIST_MODELS_CACHE_TTL_MS,
+    models: discovered,
+  };
+  return discovered;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,10 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
   for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
     const url = (block.match(/base_url:\s*(\S+)/) ?? block.match(/url:\s*(\S+)/))?.[1]?.trim();
     const key = block.match(/api_key:\s*(\S+)/)?.[1]?.trim() ?? "";
-    if (url && !endpoints.has(url)) endpoints.set(url, key);
+    if (url) {
+      // Add URL, or upgrade an existing keyless entry with a key we now have
+      if (!endpoints.has(url) || (!endpoints.get(url) && key)) endpoints.set(url, key);
+    }
   }
 
   // providers: map of name -> {api, api_key, default_model}
@@ -92,7 +95,7 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
   for (let i = 0; i < apiMatches.length; i++) {
     const url = apiMatches[i]?.[1]?.trim();
     const key = keyMatches[i]?.[1]?.trim() ?? "";
-    if (url && !endpoints.has(url)) endpoints.set(url, key);
+    if (url && (!endpoints.has(url) || (!endpoints.get(url) && key))) endpoints.set(url, key);
   }
 
   if (endpoints.size === 0) return [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { parse as parseYaml } from "yaml";
 import { ADAPTER_TYPE, ADAPTER_LABEL } from "./shared/constants.js";
 
 export const type = ADAPTER_TYPE;
@@ -25,6 +26,8 @@ export const label = ADAPTER_LABEL;
  * since Hermes availability depends on the user's local configuration.
  */
 export const models: { id: string; label: string }[] = [];
+
+type ConfigRecord = Record<string, unknown>;
 
 /**
  * Probe an OpenAI-compatible /v1/models endpoint and return sorted model entries.
@@ -51,114 +54,102 @@ async function fetchOpenAIModels(
   }
 }
 
-function parseYamlScalar(raw: string | undefined): string | undefined {
-  let value = raw?.trim();
-  if (!value) return undefined;
-
-  const quoted = value.match(/^(['"])(.*)\1\s*(?:#.*)?$/);
-  if (quoted) return quoted[2];
-
-  value = value.replace(/\s+#.*$/, "").trim();
-  return value || undefined;
+function asRecord(value: unknown): ConfigRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as ConfigRecord)
+    : null;
 }
 
-function extractIndentedSection(content: string, sectionName: string): string {
-  const lines = content.split("\n");
-  const start = lines.findIndex((line) =>
-    new RegExp(`^${sectionName}:\\s*(?:#.*)?$`).test(line),
-  );
-  if (start === -1) return "";
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  const text = String(value).trim();
+  return text || undefined;
+}
 
-  const sectionLines: string[] = [];
-  for (const line of lines.slice(start + 1)) {
-    const trimmed = line.trimStart();
-    const indent = line.length - trimmed.length;
-    if (indent === 0 && trimmed && !trimmed.startsWith("#") && !trimmed.startsWith("-")) break;
-    sectionLines.push(line);
+function parseHermesConfig(content: string): ConfigRecord | null {
+  try {
+    return asRecord(parseYaml(content));
+  } catch {
+    return null;
   }
-  return sectionLines.join("\n");
 }
 
-function readScalar(block: string, key: string): string | undefined {
-  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return parseYamlScalar(block.match(new RegExp(`^\\s+${escaped}:\\s*(.*)$`, "m"))?.[1]);
+function resolveKey(rawKey: unknown): string {
+  return asString(rawKey) ?? "";
 }
 
-function resolveKey(rawKey: string | undefined): string {
-  const inlineKey = parseYamlScalar(rawKey);
-  return inlineKey ?? "";
-}
-
-function resolveKeyEnv(rawEnvName: string | undefined): string {
-  const envName = parseYamlScalar(rawEnvName);
+function resolveKeyEnv(rawEnvName: unknown): string {
+  const envName = asString(rawEnvName);
   return envName ? (process.env[envName] ?? "") : "";
 }
 
-function normalizeEndpoint(rawUrl: string | undefined): string | undefined {
-  const url = parseYamlScalar(rawUrl)?.replace(/\/+$/, "");
+function normalizeEndpoint(rawUrl: unknown): string | undefined {
+  const url = asString(rawUrl)?.replace(/\/+$/, "");
   return url || undefined;
 }
 
-function addEndpoint(endpoints: Map<string, string>, rawUrl: string | undefined, key: string): void {
+function addEndpoint(endpoints: Map<string, string>, rawUrl: unknown, key: string): void {
   const url = normalizeEndpoint(rawUrl);
   if (!url) return;
   if (!endpoints.has(url) || (!endpoints.get(url) && key)) endpoints.set(url, key);
 }
 
-function addConfiguredModel(modelsById: Map<string, string>, model: string | undefined): void {
-  const id = parseYamlScalar(model);
+function addConfiguredModel(modelsById: Map<string, string>, model: unknown): void {
+  const id = asString(model);
   if (!id) return;
   if (!modelsById.has(id)) modelsById.set(id, id);
 }
 
-function extractCustomProviderModelKeys(block: string): string[] {
-  const lines = block.split("\n");
-  let modelsIndent: number | null = null;
-  let modelKeyIndent: number | null = null;
-  const modelKeys: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-
-    const indent = line.length - line.trimStart().length;
-    if (modelsIndent === null) {
-      if (/^models:\s*(?:#.*)?$/.test(trimmed)) modelsIndent = indent;
-      continue;
-    }
-
-    if (indent <= modelsIndent) break;
-
-    const match = line.match(/^\s*([^:#][^:]*):\s*(?:#.*)?$/);
-    if (!match) continue;
-    if (modelKeyIndent === null) modelKeyIndent = indent;
-    if (indent !== modelKeyIndent) continue;
-
-    const key = parseYamlScalar(match[1]);
-    if (key) modelKeys.push(key);
-  }
-
-  return modelKeys;
-}
-
-function extractConfiguredModels(content: string): Map<string, string> {
+function extractConfiguredModels(config: ConfigRecord): Map<string, string> {
   const modelsById = new Map<string, string>();
 
-  const modelSection = extractIndentedSection(content, "model");
-  addConfiguredModel(modelsById, readScalar(modelSection, "default"));
+  const modelConfig = asRecord(config.model);
+  addConfiguredModel(modelsById, modelConfig?.default);
 
-  const cpSection = extractIndentedSection(content, "custom_providers");
-  for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
-    addConfiguredModel(modelsById, readScalar(block, "model"));
-    for (const modelKey of extractCustomProviderModelKeys(block)) addConfiguredModel(modelsById, modelKey);
+  const customProviders = Array.isArray(config.custom_providers) ? config.custom_providers : [];
+  for (const entry of customProviders) {
+    const provider = asRecord(entry);
+    if (!provider) continue;
+    addConfiguredModel(modelsById, provider.model);
+
+    const configuredModels = asRecord(provider.models);
+    if (!configuredModels) continue;
+    for (const modelId of Object.keys(configuredModels)) addConfiguredModel(modelsById, modelId);
   }
 
-  const provSection = extractIndentedSection(content, "providers");
-  for (const block of provSection.split(/(?=^[ \t]{2}[^ \t:#][^:]*:\s*(?:#.*)?$)/m).filter(Boolean)) {
-    addConfiguredModel(modelsById, readScalar(block, "default_model"));
+  const providers = asRecord(config.providers);
+  if (providers) {
+    for (const entry of Object.values(providers)) {
+      const provider = asRecord(entry);
+      if (provider) addConfiguredModel(modelsById, provider.default_model);
+    }
   }
 
   return modelsById;
+}
+
+function collectEndpoints(config: ConfigRecord): Map<string, string> {
+  const endpoints = new Map<string, string>(); // url -> api_key
+
+  const customProviders = Array.isArray(config.custom_providers) ? config.custom_providers : [];
+  for (const entry of customProviders) {
+    const provider = asRecord(entry);
+    if (!provider) continue;
+    const key = resolveKey(provider.api_key) || resolveKeyEnv(provider.key_env);
+    addEndpoint(endpoints, provider.base_url ?? provider.url, key);
+  }
+
+  const providers = asRecord(config.providers);
+  if (providers) {
+    for (const entry of Object.values(providers)) {
+      const provider = asRecord(entry);
+      if (!provider) continue;
+      const key = resolveKey(provider.api_key) || resolveKeyEnv(provider.key_env);
+      addEndpoint(endpoints, provider.api, key);
+    }
+  }
+
+  return endpoints;
 }
 
 /**
@@ -183,26 +174,11 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
     return [];
   }
 
-  const modelsById = extractConfiguredModels(content);
+  const config = parseHermesConfig(content);
+  if (!config) return [];
 
-  // Extract unique (base_url, credential) pairs via lightweight regex parsing.
-  // Covers both the `custom_providers:` list and the `providers:` map.
-  const endpoints = new Map<string, string>(); // url -> api_key
-
-  // custom_providers: list of {name, base_url, model, api_key?, key_env?}
-  const cpSection = extractIndentedSection(content, "custom_providers");
-  for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
-    const url = readScalar(block, "base_url") ?? readScalar(block, "url");
-    const key = resolveKey(readScalar(block, "api_key")) || resolveKeyEnv(readScalar(block, "key_env"));
-    addEndpoint(endpoints, url, key);
-  }
-
-  // providers: map of name -> {api, api_key?, key_env?, default_model}
-  const provSection = extractIndentedSection(content, "providers");
-  for (const block of provSection.split(/(?=^[ \t]{2}[^ \t:#][^:]*:\s*(?:#.*)?$)/m).filter(Boolean)) {
-    const key = resolveKey(readScalar(block, "api_key")) || resolveKeyEnv(readScalar(block, "key_env"));
-    addEndpoint(endpoints, readScalar(block, "api"), key);
-  }
+  const modelsById = extractConfiguredModels(config);
+  const endpoints = collectEndpoints(config);
 
   const fetched = await Promise.all(
     [...endpoints.entries()].map(([url, key]) => fetchOpenAIModels(url, key)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,30 +51,111 @@ async function fetchOpenAIModels(
   }
 }
 
+function parseYamlScalar(raw: string | undefined): string | undefined {
+  let value = raw?.trim();
+  if (!value) return undefined;
+
+  const quoted = value.match(/^(['"])(.*)\1\s*(?:#.*)?$/);
+  if (quoted) return quoted[2];
+
+  value = value.replace(/\s+#.*$/, "").trim();
+  return value || undefined;
+}
+
+function extractIndentedSection(content: string, sectionName: string): string {
+  const lines = content.split("\n");
+  const start = lines.findIndex((line) =>
+    new RegExp(`^${sectionName}:\\s*(?:#.*)?$`).test(line),
+  );
+  if (start === -1) return "";
+
+  const sectionLines: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    const trimmed = line.trimStart();
+    const indent = line.length - trimmed.length;
+    if (indent === 0 && trimmed && !trimmed.startsWith("#") && !trimmed.startsWith("-")) break;
+    sectionLines.push(line);
+  }
+  return sectionLines.join("\n");
+}
+
+function readScalar(block: string, key: string): string | undefined {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return parseYamlScalar(block.match(new RegExp(`^\\s+${escaped}:\\s*(.*)$`, "m"))?.[1]);
+}
+
+function resolveKey(rawKey: string | undefined): string {
+  const inlineKey = parseYamlScalar(rawKey);
+  return inlineKey ?? "";
+}
+
+function resolveKeyEnv(rawEnvName: string | undefined): string {
+  const envName = parseYamlScalar(rawEnvName);
+  return envName ? (process.env[envName] ?? "") : "";
+}
+
+function normalizeEndpoint(rawUrl: string | undefined): string | undefined {
+  const url = parseYamlScalar(rawUrl)?.replace(/\/+$/, "");
+  return url || undefined;
+}
+
+function addEndpoint(endpoints: Map<string, string>, rawUrl: string | undefined, key: string): void {
+  const url = normalizeEndpoint(rawUrl);
+  if (!url) return;
+  if (!endpoints.has(url) || (!endpoints.get(url) && key)) endpoints.set(url, key);
+}
+
 function addConfiguredModel(modelsById: Map<string, string>, model: string | undefined): void {
-  const id = model?.trim();
+  const id = parseYamlScalar(model);
   if (!id) return;
   if (!modelsById.has(id)) modelsById.set(id, id);
+}
+
+function extractCustomProviderModelKeys(block: string): string[] {
+  const lines = block.split("\n");
+  let modelsIndent: number | null = null;
+  let modelKeyIndent: number | null = null;
+  const modelKeys: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const indent = line.length - line.trimStart().length;
+    if (modelsIndent === null) {
+      if (/^models:\s*(?:#.*)?$/.test(trimmed)) modelsIndent = indent;
+      continue;
+    }
+
+    if (indent <= modelsIndent) break;
+
+    const match = line.match(/^\s*([^:#][^:]*):\s*(?:#.*)?$/);
+    if (!match) continue;
+    if (modelKeyIndent === null) modelKeyIndent = indent;
+    if (indent !== modelKeyIndent) continue;
+
+    const key = parseYamlScalar(match[1]);
+    if (key) modelKeys.push(key);
+  }
+
+  return modelKeys;
 }
 
 function extractConfiguredModels(content: string): Map<string, string> {
   const modelsById = new Map<string, string>();
 
-  const modelSection = content.match(/^model:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
-  addConfiguredModel(modelsById, modelSection.match(/^\s+default:\s*(\S+)/m)?.[1]);
+  const modelSection = extractIndentedSection(content, "model");
+  addConfiguredModel(modelsById, readScalar(modelSection, "default"));
 
-  const cpSection =
-    content.match(/^custom_providers:\s*\n((?:[ \t]+-[^\n]*\n(?:[ \t][^\n]*\n)*)*)/m)?.[1] ?? "";
+  const cpSection = extractIndentedSection(content, "custom_providers");
   for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
-    addConfiguredModel(modelsById, block.match(/^\s+model:\s*(\S+)/m)?.[1]);
-    for (const modelMatch of block.matchAll(/^\s{4}([A-Za-z0-9._:/-]+):\s*$/gm)) {
-      addConfiguredModel(modelsById, modelMatch[1]);
-    }
+    addConfiguredModel(modelsById, readScalar(block, "model"));
+    for (const modelKey of extractCustomProviderModelKeys(block)) addConfiguredModel(modelsById, modelKey);
   }
 
-  const provSection = content.match(/^providers:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
-  for (const match of provSection.matchAll(/^\s+default_model:\s*(\S+)/gm)) {
-    addConfiguredModel(modelsById, match[1]);
+  const provSection = extractIndentedSection(content, "providers");
+  for (const block of provSection.split(/(?=^[ \t]{2}[^ \t:#][^:]*:\s*(?:#.*)?$)/m).filter(Boolean)) {
+    addConfiguredModel(modelsById, readScalar(block, "default_model"));
   }
 
   return modelsById;
@@ -93,7 +174,7 @@ function extractConfiguredModels(content: string): Map<string, string> {
  * unreachable.
  */
 export async function listModels(): Promise<{ id: string; label: string }[]> {
-  const hermesHome = process.env["HERMES_HOME"] ?? join(homedir(), ".hermes");
+  const hermesHome = process.env["HERMES_HOME"]?.trim() || join(homedir(), ".hermes");
   const configPath = join(hermesHome, "config.yaml");
   let content: string;
   try {
@@ -109,32 +190,18 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
   const endpoints = new Map<string, string>(); // url -> api_key
 
   // custom_providers: list of {name, base_url, model, api_key?, key_env?}
-  const cpSection =
-    content.match(/^custom_providers:\s*\n((?:[ \t]+-[^\n]*\n(?:[ \t][^\n]*\n)*)*)/m)?.[1] ?? "";
+  const cpSection = extractIndentedSection(content, "custom_providers");
   for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
-    const url = (block.match(/base_url:\s*(\S+)/) ?? block.match(/url:\s*(\S+)/))?.[1]?.trim();
-    const key =
-      block.match(/api_key:\s*(\S+)/)?.[1]?.trim() ??
-      process.env[block.match(/key_env:\s*(\S+)/)?.[1]?.trim() ?? ""] ??
-      "";
-    if (url) {
-      // Add URL, or upgrade an existing keyless entry with a key we now have
-      if (!endpoints.has(url) || (!endpoints.get(url) && key)) endpoints.set(url, key);
-    }
+    const url = readScalar(block, "base_url") ?? readScalar(block, "url");
+    const key = resolveKey(readScalar(block, "api_key")) || resolveKeyEnv(readScalar(block, "key_env"));
+    addEndpoint(endpoints, url, key);
   }
 
   // providers: map of name -> {api, api_key?, key_env?, default_model}
-  const provSection = content.match(/^providers:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
-  const apiMatches = [...provSection.matchAll(/^\s+api:\s*(\S+)/gm)];
-  const keyMatches = [...provSection.matchAll(/^\s+api_key:\s*(\S+)/gm)];
-  const keyEnvMatches = [...provSection.matchAll(/^\s+key_env:\s*(\S+)/gm)];
-  for (let i = 0; i < apiMatches.length; i++) {
-    const url = apiMatches[i]?.[1]?.trim();
-    const key =
-      keyMatches[i]?.[1]?.trim() ??
-      process.env[keyEnvMatches[i]?.[1]?.trim() ?? ""] ??
-      "";
-    if (url && (!endpoints.has(url) || (!endpoints.get(url) && key))) endpoints.set(url, key);
+  const provSection = extractIndentedSection(content, "providers");
+  for (const block of provSection.split(/(?=^[ \t]{2}[^ \t:#][^:]*:\s*(?:#.*)?$)/m).filter(Boolean)) {
+    const key = resolveKey(readScalar(block, "api_key")) || resolveKeyEnv(readScalar(block, "key_env"));
+    addEndpoint(endpoints, readScalar(block, "api"), key);
   }
 
   const fetched = await Promise.all(

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,16 +51,46 @@ async function fetchOpenAIModels(
   }
 }
 
+function addConfiguredModel(modelsById: Map<string, string>, model: string | undefined): void {
+  const id = model?.trim();
+  if (!id) return;
+  if (!modelsById.has(id)) modelsById.set(id, id);
+}
+
+function extractConfiguredModels(content: string): Map<string, string> {
+  const modelsById = new Map<string, string>();
+
+  const modelSection = content.match(/^model:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
+  addConfiguredModel(modelsById, modelSection.match(/^\s+default:\s*(\S+)/m)?.[1]);
+
+  const cpSection =
+    content.match(/^custom_providers:\s*\n((?:[ \t]+-[^\n]*\n(?:[ \t][^\n]*\n)*)*)/m)?.[1] ?? "";
+  for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
+    addConfiguredModel(modelsById, block.match(/^\s+model:\s*(\S+)/m)?.[1]);
+    for (const modelMatch of block.matchAll(/^\s{4}([A-Za-z0-9._:/-]+):\s*$/gm)) {
+      addConfiguredModel(modelsById, modelMatch[1]);
+    }
+  }
+
+  const provSection = content.match(/^providers:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
+  for (const match of provSection.matchAll(/^\s+default_model:\s*(\S+)/gm)) {
+    addConfiguredModel(modelsById, match[1]);
+  }
+
+  return modelsById;
+}
+
 /**
  * List all models available from the user's Hermes config.
  *
  * Reads `~/.hermes/config.yaml` (or `$HERMES_HOME/config.yaml`), extracts
- * unique `base_url` + `api_key` pairs from the `custom_providers` list and
- * `providers` map, probes each endpoint's `/v1/models` in parallel, and
- * returns the deduplicated, sorted result.
+ * configured model ids plus unique `base_url` + credential pairs from the
+ * `custom_providers` list and `providers` map, probes each endpoint's
+ * `/v1/models` in parallel, and returns the deduplicated, sorted result.
  *
- * Falls back gracefully to an empty list if the config is missing or any
- * endpoint is unreachable.
+ * Falls back gracefully to configured model ids if the config uses `key_env`
+ * credentials that are not available to the Paperclip process or an endpoint is
+ * unreachable.
  */
 export async function listModels(): Promise<{ id: string; label: string }[]> {
   const hermesHome = process.env["HERMES_HOME"] ?? join(homedir(), ".hermes");
@@ -72,49 +102,53 @@ export async function listModels(): Promise<{ id: string; label: string }[]> {
     return [];
   }
 
-  // Extract unique (base_url, api_key) pairs via lightweight regex parsing.
+  const modelsById = extractConfiguredModels(content);
+
+  // Extract unique (base_url, credential) pairs via lightweight regex parsing.
   // Covers both the `custom_providers:` list and the `providers:` map.
   const endpoints = new Map<string, string>(); // url -> api_key
 
-  // custom_providers: list of {name, base_url, model, api_key?}
+  // custom_providers: list of {name, base_url, model, api_key?, key_env?}
   const cpSection =
     content.match(/^custom_providers:\s*\n((?:[ \t]+-[^\n]*\n(?:[ \t][^\n]*\n)*)*)/m)?.[1] ?? "";
   for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
     const url = (block.match(/base_url:\s*(\S+)/) ?? block.match(/url:\s*(\S+)/))?.[1]?.trim();
-    const key = block.match(/api_key:\s*(\S+)/)?.[1]?.trim() ?? "";
+    const key =
+      block.match(/api_key:\s*(\S+)/)?.[1]?.trim() ??
+      process.env[block.match(/key_env:\s*(\S+)/)?.[1]?.trim() ?? ""] ??
+      "";
     if (url) {
       // Add URL, or upgrade an existing keyless entry with a key we now have
       if (!endpoints.has(url) || (!endpoints.get(url) && key)) endpoints.set(url, key);
     }
   }
 
-  // providers: map of name -> {api, api_key, default_model}
+  // providers: map of name -> {api, api_key?, key_env?, default_model}
   const provSection = content.match(/^providers:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
   const apiMatches = [...provSection.matchAll(/^\s+api:\s*(\S+)/gm)];
   const keyMatches = [...provSection.matchAll(/^\s+api_key:\s*(\S+)/gm)];
+  const keyEnvMatches = [...provSection.matchAll(/^\s+key_env:\s*(\S+)/gm)];
   for (let i = 0; i < apiMatches.length; i++) {
     const url = apiMatches[i]?.[1]?.trim();
-    const key = keyMatches[i]?.[1]?.trim() ?? "";
+    const key =
+      keyMatches[i]?.[1]?.trim() ??
+      process.env[keyEnvMatches[i]?.[1]?.trim() ?? ""] ??
+      "";
     if (url && (!endpoints.has(url) || (!endpoints.get(url) && key))) endpoints.set(url, key);
   }
-
-  if (endpoints.size === 0) return [];
 
   const fetched = await Promise.all(
     [...endpoints.entries()].map(([url, key]) => fetchOpenAIModels(url, key)),
   );
 
-  const seen = new Set<string>();
-  const results: { id: string; label: string }[] = [];
   for (const batch of fetched) {
     for (const m of batch) {
-      if (!seen.has(m.id)) {
-        seen.add(m.id);
-        results.push(m);
-      }
+      if (!modelsById.has(m.id)) modelsById.set(m.id, m.label);
     }
   }
-  return results.sort((a, b) => a.id.localeCompare(b.id));
+  return [...modelsById.entries()]
+    .map(([id, label]) => ({ id, label }))
+    .sort((a, b) => a.id.localeCompare(b.id));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@
  * @packageDocumentation
  */
 
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import { ADAPTER_TYPE, ADAPTER_LABEL } from "./shared/constants.js";
 
 export const type = ADAPTER_TYPE;
@@ -22,6 +25,94 @@ export const label = ADAPTER_LABEL;
  * since Hermes availability depends on the user's local configuration.
  */
 export const models: { id: string; label: string }[] = [];
+
+/**
+ * Probe an OpenAI-compatible /v1/models endpoint and return sorted model entries.
+ * Returns an empty array on any error so callers can fall back gracefully.
+ */
+async function fetchOpenAIModels(
+  baseUrl: string,
+  apiKey: string,
+): Promise<{ id: string; label: string }[]> {
+  try {
+    const url = baseUrl.replace(/\/$/, "") + "/models";
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { data?: unknown[] };
+    const items = Array.isArray(data?.data) ? data.data : [];
+    return (items as { id?: string }[])
+      .filter((m) => typeof m?.id === "string")
+      .map((m) => ({ id: m.id as string, label: m.id as string }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List all models available from the user's Hermes config.
+ *
+ * Reads `~/.hermes/config.yaml` (or `$HERMES_HOME/config.yaml`), extracts
+ * unique `base_url` + `api_key` pairs from the `custom_providers` list and
+ * `providers` map, probes each endpoint's `/v1/models` in parallel, and
+ * returns the deduplicated, sorted result.
+ *
+ * Falls back gracefully to an empty list if the config is missing or any
+ * endpoint is unreachable.
+ */
+export async function listModels(): Promise<{ id: string; label: string }[]> {
+  const hermesHome = process.env["HERMES_HOME"] ?? join(homedir(), ".hermes");
+  const configPath = join(hermesHome, "config.yaml");
+  let content: string;
+  try {
+    content = await readFile(configPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  // Extract unique (base_url, api_key) pairs via lightweight regex parsing.
+  // Covers both the `custom_providers:` list and the `providers:` map.
+  const endpoints = new Map<string, string>(); // url -> api_key
+
+  // custom_providers: list of {name, base_url, model, api_key?}
+  const cpSection =
+    content.match(/^custom_providers:\s*\n((?:[ \t]+-[^\n]*\n(?:[ \t][^\n]*\n)*)*)/m)?.[1] ?? "";
+  for (const block of cpSection.split(/(?=^\s+-\s)/m).filter(Boolean)) {
+    const url = (block.match(/base_url:\s*(\S+)/) ?? block.match(/url:\s*(\S+)/))?.[1]?.trim();
+    const key = block.match(/api_key:\s*(\S+)/)?.[1]?.trim() ?? "";
+    if (url && !endpoints.has(url)) endpoints.set(url, key);
+  }
+
+  // providers: map of name -> {api, api_key, default_model}
+  const provSection = content.match(/^providers:\s*\n((?:[ \t][^\n]*\n)*)/m)?.[1] ?? "";
+  const apiMatches = [...provSection.matchAll(/^\s+api:\s*(\S+)/gm)];
+  const keyMatches = [...provSection.matchAll(/^\s+api_key:\s*(\S+)/gm)];
+  for (let i = 0; i < apiMatches.length; i++) {
+    const url = apiMatches[i]?.[1]?.trim();
+    const key = keyMatches[i]?.[1]?.trim() ?? "";
+    if (url && !endpoints.has(url)) endpoints.set(url, key);
+  }
+
+  if (endpoints.size === 0) return [];
+
+  const fetched = await Promise.all(
+    [...endpoints.entries()].map(([url, key]) => fetchOpenAIModels(url, key)),
+  );
+
+  const seen = new Set<string>();
+  const results: { id: string; label: string }[] = [];
+  for (const batch of fetched) {
+    for (const m of batch) {
+      if (!seen.has(m.id)) {
+        seen.add(m.id);
+        results.push(m);
+      }
+    }
+  }
+  return results.sort((a, b) => a.id.localeCompare(b.id));
+}
 
 /**
  * Documentation shown in the Paperclip UI when configuring a Hermes agent.

--- a/src/server/detect-model.ts
+++ b/src/server/detect-model.ts
@@ -1,8 +1,8 @@
 /**
  * Detect the current model and provider from the user's Hermes config.
  *
- * Reads ~/.hermes/config.yaml and extracts the default model,
- * provider, base_url, and api_mode settings.
+ * Reads $HERMES_HOME/config.yaml or ~/.hermes/config.yaml and extracts the
+ * default model, provider, base_url, and api_mode settings.
  *
  * Also provides provider resolution logic that merges explicit config,
  * Hermes config detection, and model-name prefix inference.
@@ -32,7 +32,8 @@ export interface DetectedModel {
 export async function detectModel(
   configPath?: string,
 ): Promise<DetectedModel | null> {
-  const filePath = configPath ?? join(process.env["HERMES_HOME"] ?? join(homedir(), ".hermes"), "config.yaml");
+  const hermesHome = process.env["HERMES_HOME"]?.trim() || join(homedir(), ".hermes");
+  const filePath = configPath ?? join(hermesHome, "config.yaml");
 
   let content: string;
   try {

--- a/src/server/detect-model.ts
+++ b/src/server/detect-model.ts
@@ -32,7 +32,7 @@ export interface DetectedModel {
 export async function detectModel(
   configPath?: string,
 ): Promise<DetectedModel | null> {
-  const filePath = configPath ?? join(homedir(), ".hermes", "config.yaml");
+  const filePath = configPath ?? join(process.env["HERMES_HOME"] ?? join(homedir(), ".hermes"), "config.yaml");
 
   let content: string;
   try {


### PR DESCRIPTION
Extends #54 so Hermes model discovery still returns useful options when config uses env-backed credentials instead of inline `api_key` values.

- Keeps `/v1/models` probing for inline `api_key` values or available `key_env` credentials
- Also returns configured `model.default`, provider `default_model`, and custom provider model ids
- Covers local Paperclip/Hermes setups where the Hermes config names `XAI_API_KEY`, but the Paperclip process does not have that secret in its environment

Verified with `npm run typecheck`, `npm run build`, and a `HERMES_HOME` smoke config that returns the configured Grok models without reading a real key.