### PR TITLE
fix(0.3.1): jq prompt template + persistSession default false + error surface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company",
   "type": "module",
   "license": "MIT",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -108,7 +108,7 @@ Address the comment, POST a reply if needed, then continue working.
 ## Heartbeat Wake — Check for Work
 
 1. List ALL open issues assigned to you (todo, backlog, in_progress):
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
+   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | jq -r '.[] | select(.status != "done" and .status != "cancelled") | "\\(.identifier) \\(.status) \\(.priority) \\(.title)"' \`
 
 2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
    - Read the issue details: \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
@@ -116,7 +116,7 @@ Address the comment, POST a reply if needed, then continue working.
    - When done, mark complete and post a comment (see Workflow steps 2-4 above)
 
 3. If no issues assigned to you, check for unassigned issues:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
+   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | jq -r '.[] | select(.assigneeAgentId == null) | "\\(.identifier) \\(.title)"' \`
    If you find a relevant issue, assign it to yourself:
    \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
 
@@ -322,7 +322,10 @@ export async function execute(
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
   const extraArgs = cfgStringArray(config.extraArgs);
-  const persistSession = cfgBoolean(config.persistSession) !== false;
+  // Default false: every wake should re-evaluate from scratch. A stale
+  // "all set" turn must not survive across heartbeats. Opt in with
+  // adapterConfig.persistSession=true if you want resume.
+  const persistSession = cfgBoolean(config.persistSession) === true;
   const worktreeMode = cfgBoolean(config.worktreeMode) === true;
   const checkpoints = cfgBoolean(config.checkpoints) === true;
 
@@ -500,6 +503,22 @@ export async function execute(
 
   if (parsed.errorMessage) {
     executionResult.errorMessage = parsed.errorMessage;
+  } else if (
+    (result.exitCode !== 0 && result.exitCode != null) ||
+    result.timedOut
+  ) {
+    // Fallback: surface something actionable when parseHermesOutput's
+    // error-line heuristic finds nothing but the child still failed.
+    const tail = (result.stderr || "")
+      .split("\n")
+      .map((l) => l.trimEnd())
+      .filter((l) => l.length > 0)
+      .slice(-5)
+      .join("\n");
+    const header = result.timedOut
+      ? `Hermes timed out after ${timeoutSec}s (signal=${result.signal ?? "n/a"})`
+      : `Hermes exited with code ${result.exitCode}`;
+    executionResult.errorMessage = tail ? `${header}\n${tail}` : header;
   }
 
   if (parsed.usage) {


### PR DESCRIPTION
## Summary

Bumps `hermes-paperclip-adapter` to **0.3.1** and ships three fixes we hit while running 0.3.0 in production at Paperclip. All three live in `src/server/execute.ts`.

### Bug 1 — broken Python f-string in `DEFAULT_PROMPT_TEMPLATE`

The wake-up prompt told the Hermes agent to list its inbox with:

```python
python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]"
```

When this passes through the JSON-encoded chat protocol → tool round-trip, the inner `\"identifier\"` quotes get re-quoted, and on some models Hermes ends up running syntactically-broken Python (literal `f'{i[identifier] ...}'` without the inner quotes) — a `SyntaxError` from `script.py`. Stronger models retry with a different formulation; weaker routing (e.g. `openrouter/auto` landing on a small model) just gives up and answers "I am all set."

**Fix:** replace both Python f-string blocks (assigned-issues + unassigned-issues listings) with a `jq` one-liner that does not depend on f-string quoting:

```bash
curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "$URL" \
  | jq -r '.[] | select(.status != "done" and .status != "cancelled") | "\(.identifier) \(.status) \(.priority) \(.title)"'
```

### Bug 2 — `persistSession: true` is the wrong default

`execute.ts` defaulted `persistSession = cfgBoolean(config.persistSession) !== false`. For `wakeOnDemand` agents (`runtimeConfig.heartbeat.enabled = false`), every wake should re-evaluate the inbox from scratch; carrying a prior "I am all set" turn poisons the next decision. Once the broken Python in Bug 1 fired, the resumed session locked the conclusion forever — we reproduced this 4+ times before isolating it.

**Fix:** flip the default to `false`. Resume is still available, but it must be explicitly opted into with `adapterConfig.persistSession=true`. The new comment at the call-site documents the rationale.

### Bug 4 — `adapter_failed - Adapter failed.` carries no detail

When a Hermes run errors, the system retry comment surfaces only the literal string `Adapter failed.`. `parseHermesOutput` only matches `/error|exception|traceback|failed/i AND NOT INFO|DEBUG|warn`, so structured CLI exits leave `errorMessage` empty.

**Fix:** when the child exits non-zero (or times out) and `parsed.errorMessage` is empty, fall back to `Hermes exited with code N` (or `timed out after Ns`) plus the last five non-empty stderr lines. Operators now see something actionable.

## Out of scope

- Per-agent `~/.hermes/memories/MEMORY.md` isolation (Bug 3 from our internal tracker) — depends on a `hermes-agent` env-var change and is being handled separately.
- Smoke test of the patched build under Paperclip — runs against the published artifact, not this PR.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run build` — clean.
- Hot-patched `dist/server/execute.js` has been running on the Paperclip side for several heartbeats and we no longer see the canned "I am all set" loop or the bare `Adapter failed.` message.

## Repro / context

Paperclip-side ticket with full repro + session traces: `PHO-152`. Happy to share more detail or session logs on request.