### PR TITLE
fix: avoid unsafe pipe-to-interpreter prompt commands

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -98,8 +98,8 @@ Title: {{taskTitle}}
 {{#commentId}}
 ## Comment on This Issue
 
-Someone commented. Read it:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}" | python3 -m json.tool\`
+Someone commented. Read it with a safe local JSON helper, not a pipe-to-interpreter command:
+   \`python3 -c 'import json,os,urllib.request; url="{{paperclipApiUrl}}/issues/{{taskId}}/comments/{{commentId}}"; req=urllib.request.Request(url, headers={"Authorization":"Bearer "+os.environ.get("PAPERCLIP_API_KEY","")}); print(json.dumps(json.load(urllib.request.urlopen(req)), indent=2, ensure_ascii=False))'\`
 
 Address the comment, POST a reply if needed, then continue working.
 {{/commentId}}
@@ -108,7 +108,7 @@ Address the comment, POST a reply if needed, then continue working.
 ## Heartbeat Wake — Check for Work
 
 1. List ALL open issues assigned to you (todo, backlog, in_progress):
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?assigneeAgentId={{agentId}}" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"status\"]:>12} {i[\"priority\"]:>6} {i[\"title\"]}') for i in issues if i['status'] not in ('done','cancelled')]" \`
+   \`python3 -c 'import json,os,urllib.parse,urllib.request; url="{{paperclipApiUrl}}/companies/{{companyId}}/issues?"+urllib.parse.urlencode({"assigneeAgentId":"{{agentId}}"}); req=urllib.request.Request(url, headers={"Authorization":"Bearer "+os.environ.get("PAPERCLIP_API_KEY","")}); issues=json.load(urllib.request.urlopen(req)); [print(f"{i.get(\"identifier\")} {i.get(\"status\",\"\"):>12} {i.get(\"priority\",\"\"):>6} {i.get(\"title\",\"\")}") for i in issues if i.get("status") not in ("done","cancelled")]'\`
 
 2. If issues found, pick the highest priority one that is not done/cancelled and work on it:
    - Read the issue details: \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID"\`
@@ -116,7 +116,7 @@ Address the comment, POST a reply if needed, then continue working.
    - When done, mark complete and post a comment (see Workflow steps 2-4 above)
 
 3. If no issues assigned to you, check for unassigned issues:
-   \`curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/companies/{{companyId}}/issues?status=backlog" | python3 -c "import sys,json;issues=json.loads(sys.stdin.read());[print(f'{i[\"identifier\"]} {i[\"title\"]}') for i in issues if not i.get('assigneeAgentId')]" \`
+   \`python3 -c 'import json,os,urllib.parse,urllib.request; url="{{paperclipApiUrl}}/companies/{{companyId}}/issues?"+urllib.parse.urlencode({"status":"backlog"}); req=urllib.request.Request(url, headers={"Authorization":"Bearer "+os.environ.get("PAPERCLIP_API_KEY","")}); issues=json.load(urllib.request.urlopen(req)); [print(f"{i.get(\"identifier\")} {i.get(\"title\",\"\")}") for i in issues if not i.get("assigneeAgentId")]'\`
    If you find a relevant issue, assign it to yourself:
    \`curl -s -X PATCH -H "Authorization: Bearer $PAPERCLIP_API_KEY" "{{paperclipApiUrl}}/issues/ISSUE_ID" -H "Content-Type: application/json" -d '{"assigneeAgentId":"{{agentId}}","status":"todo"}'\`
 


### PR DESCRIPTION
## Summary
- Replaces heartbeat prompt examples that pipe network output directly into `python3`.
- Uses `python3 -c` with `urllib.request` and explicit Authorization headers instead.
- Keeps the prompt behavior equivalent while avoiding unsafe pipe-to-interpreter command patterns.

## Test Plan
- `npm run build`
- `git diff --check`
