### PR TITLE
fix: add missing providers to VALID_PROVIDERS whitelist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
     "./cli": "./dist/cli/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "tsconfig.json"
   ],
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -420,9 +420,18 @@ export async function execute(
   const taskId = cfgString(ctx.config?.taskId);
   if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
-  const userEnv = config.env as Record<string, string> | undefined;
+  const userEnv = config.env as Record<string, unknown> | undefined;
   if (userEnv && typeof userEnv === "object") {
-    Object.assign(env, userEnv);
+    // Paperclip may serialize env values as wrapper objects:
+    //   { "KEY": { "type": "plain", "value": "..." } }
+    // Resolve them to raw strings so the child process receives valid values.
+    for (const [key, val] of Object.entries(userEnv)) {
+      if (val && typeof val === "object" && "value" in val) {
+        env[key] = String((val as { value: unknown }).value);
+      } else if (val != null) {
+        env[key] = String(val);
+      }
+    }
   }
 
   // ── Resolve working directory ──────────────────────────────────────────

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -358,8 +358,9 @@ export async function execute(
   const prompt = buildPrompt(ctx, config);
 
   // ── Build command args ─────────────────────────────────────────────────
-  // Use -Q (quiet) to get clean output: just response + session_id line
-  const useQuiet = cfgBoolean(config.quiet) !== false; // default true
+  // -Q (quiet) suppresses stdout — response only on stderr, transcript empty.
+  // Default false so adapter captures full Hermes output for transcript parsing.
+  const useQuiet = cfgBoolean(config.quiet) === true; // default false
   const args: string[] = ["chat", "-q", prompt];
   if (useQuiet) args.push("-Q");
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,6 +38,12 @@ export const VALID_PROVIDERS = [
   "minimax",
   "minimax-cn",
   "kilocode",
+  "custom",
+  "ollama-cloud",
+  "deepseek",
+  "nvidia",
+  "xai",
+  "bedrock",
 ] as const;
 
 /**


### PR DESCRIPTION
## Problem

The `VALID_PROVIDERS` array in `constants.ts` is missing several providers that Hermes CLI supports. When an agent is configured with `provider: "custom"` (or any other missing provider) in `adapterConfig`, the adapter silently drops the `--provider` flag because `resolveProvider()` checks `VALID_PROVIDERS.includes(explicitProvider)` and falls back to auto-detection.

This blocks all self-hosted/local model deployments via `hermes_local`, since the standard Hermes configuration for local models is:

```yaml
model:
  provider: custom
  base_url: http://localhost:8080/v1
```

### Reproduction

1. Create a Paperclip agent with `adapterType: "hermes_local"`, `adapterConfig.provider: "custom"`
2. Trigger heartbeat
3. Observe: adapter log shows `provider=auto [auto]` instead of `provider=custom [adapterConfig]`
4. Hermes auto-detects wrong provider, fails to reach local model

At scale: 44/44 hermes_local experiments skipped in our evaluation matrix due to this issue.

## Fix

Add the missing providers from Hermes's supported list to `VALID_PROVIDERS`:

- `custom` — self-hosted endpoints (Ollama, vLLM, mlx_lm, llama.cpp, etc.)
- `ollama-cloud` — Ollama Cloud
- `deepseek` — DeepSeek API
- `nvidia` — NVIDIA NIM
- `xai` — xAI/Grok
- `bedrock` — AWS Bedrock

Reference: [Hermes provider docs](https://hermes-agent.nousresearch.com/docs/integrations/providers) lists the full set:
> Supported providers: openrouter, nous, openai-codex, copilot, copilot-acp, anthropic, gemini, google-gemini-cli, qwen-oauth, huggingface, zai, kimi-coding, kimi-coding-cn, minimax, minimax-cn, minimax-oauth, deepseek, nvidia, xai, ollama-cloud, bedrock, ai-gateway, opencode-zen, opencode-go, kilocode, xiaomi, arcee, gmi, alibaba, tencent-tokenhub, **custom**.

## Also included

- `prepare` script in package.json so `npm install` from git URLs auto-builds TypeScript

## Testing

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm install` from git URL produces working dist/ with \`custom\` in VALID_PROVIDERS

## Related

- #76 (preserve env-only Hermes providers)
- #78 (normalize adapter env values)
- #54 (listModels for custom provider endpoints)