### PR TITLE
feat: support subscription-backed providers (Codex, Copilot) for Paperclip agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company",
   "type": "module",
   "license": "MIT",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -63,6 +63,26 @@ function cfgStringArray(v: unknown): string[] | undefined {
     : undefined;
 }
 
+/**
+ * Coerce a Paperclip env-value (which may be a plain string, a structured
+ * `{ type: "plain"|"secret"|"env", value: "..." }` secret object, or
+ * something invalid) into the plain string form expected by child_process.
+ *
+ * Returns `undefined` for values that should NOT be set (empty strings,
+ * non-string values inside the wrapper, unknown shapes). The caller drops
+ * these so they don't clobber inherited env vars like HOME.
+ */
+function coerceEnvValue(raw: unknown): string | undefined {
+  if (typeof raw === "string") {
+    return raw.length > 0 ? raw : undefined;
+  }
+  if (raw && typeof raw === "object") {
+    const v = (raw as { value?: unknown }).value;
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -420,9 +440,17 @@ export async function execute(
   const taskId = cfgString(ctx.config?.taskId);
   if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
-  const userEnv = config.env as Record<string, string> | undefined;
+  // Paperclip stores per-agent env vars in a structured-secret shape:
+  //   { type: "plain"|"secret"|"env", value: "..." }
+  // Older code did Object.assign(env, userEnv) which clobbered HOME (and
+  // others) with "[object Object]", breaking ~/.hermes/config.yaml lookup.
+  // Unwrap to plain strings, drop empty/invalid entries.
+  const userEnv = config.env as Record<string, unknown> | undefined;
   if (userEnv && typeof userEnv === "object") {
-    Object.assign(env, userEnv);
+    for (const [key, raw] of Object.entries(userEnv)) {
+      const coerced = coerceEnvValue(raw);
+      if (coerced !== undefined) env[key] = coerced;
+    }
   }
 
   // ── Resolve working directory ──────────────────────────────────────────

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -14,6 +14,7 @@ import type { CreateConfigValues } from "@paperclipai/adapter-utils";
 
 import {
   DEFAULT_TIMEOUT_SEC,
+  VALID_PROVIDERS,
 } from "../shared/constants.js";
 
 /**
@@ -29,16 +30,21 @@ export function buildHermesConfig(
     ac.model = v.model.trim();
   }
 
-  // NOTE: Provider is NOT set here because the Paperclip UI form
-  // (CreateConfigValues) does not expose a provider field.
-  // Instead, provider is resolved at runtime in execute.ts using
-  // a priority chain:
-  //   1. adapterConfig.provider (if set via API directly)
-  //   2. ~/.hermes/config.yaml detection
-  //   3. Model-name prefix inference
-  //   4. "auto" fallback
-  // This ensures correct provider routing even for agents created
-  // before provider tracking existed.
+  // Provider: persist if the Paperclip create-form passed one (e.g. for
+  // subscription-backed providers like openai-codex). The base
+  // CreateConfigValues type does not declare `provider`, but downstream
+  // forms can extend it; we accept it via duck-typing.
+  // If absent, runtime in execute.ts resolves via:
+  //   1. ~/.hermes/config.yaml detection
+  //   2. Model-name prefix inference
+  //   3. "auto" fallback
+  const providerCandidate = (v as { provider?: unknown }).provider;
+  if (
+    typeof providerCandidate === "string" &&
+    (VALID_PROVIDERS as readonly string[]).includes(providerCandidate)
+  ) {
+    ac.provider = providerCandidate;
+  }
 
   // Execution limits — let the user configure these from the Paperclip UI.
   // timeoutSec: wall-clock kill timeout for the hermes child process.


### PR DESCRIPTION
## Summary
Enable Paperclip-managed Hermes agents to run against subscription-backed inference providers like OpenAI Codex Plus/Pro and GitHub Copilot.

Two changes are needed to make this work end-to-end:

1. **`buildHermesConfig` accepts an explicit `provider`.** Persisted when the Paperclip create-form passes one (validated against `VALID_PROVIDERS`). Downstream forms can extend `CreateConfigValues` to expose a Provider selector; we accept it via duck-typing so the base type doesn't need to change. When no provider is set, the existing runtime chain still applies (`~/.hermes/config.yaml` → model-prefix inference → `"auto"`).

2. **Fix the child-env corruption bug that made subscription providers unusable.** Paperclip stores per-agent env vars in a structured-secret shape:

   ```
   { type: "plain" | "secret" | "env", value: "..." }
   ```

   The previous \`Object.assign(env, userEnv)\` serialized those wrappers to \`"[object Object]"\`, so a common pattern like \`adapterConfig.env.HOME = "/Users/<user>"\` caused the spawned hermes to see \`HOME="[object Object]"\`, fail to read \`~/.hermes/config.yaml\`, and trip the first-run guard:

   > It looks like Hermes isn't configured yet — no API keys or providers found.

   New \`coerceEnvValue()\` helper unwraps the wrapper shape and drops empty/invalid entries before merging into the spawn env.

Bumps \`0.3.0\` → \`0.3.1\`.

## Test plan
- [x] Reproduced the failure on a real Paperclip agent with \`adapterConfig.env.HOME\` set as a \`{type, value}\` secret.
- [x] After patch + \`npm run build\`, the same agent runs successfully under \`provider=openai-codex\` resolved from \`adapterConfig\`: \`[hermes] Starting Hermes Agent (model=…, provider=openai-codex [adapterConfig], …)\` → exit 0, real work performed end-to-end.
- [x] \`npm run build\` (tsc) clean.

## Notes
The repo doesn't currently have a unit-test runner. Happy to add tests for \`coerceEnvValue\` and the provider passthrough if you'd like — just let me know your preferred framework (or whether you'd prefer a zero-dep \`node --test\` file).