### PR TITLE
fix: wire onSpawn in runChildProcess call

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -476,6 +476,7 @@ export async function execute(
     timeoutSec,
     graceSec,
     onLog: wrappedOnLog,
+    onSpawn: ctx.onSpawn,
   });
 
   // ── Parse output ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Passes `onSpawn: ctx.onSpawn` to the `runChildProcess` call in `execute.ts` so Paperclip can track the Hermes child PID.

## Problem

`runChildProcess` was called without `onSpawn`, so the `opts.onSpawn` callback in `@paperclipai/adapter-utils/server-utils.js` was never invoked. As a result, Paperclip never called `persistRunProcessMetadata`, and `heartbeat_runs.process_pid` stayed `NULL` for every Hermes run.

This broke the orphan-process reaper's liveness check — without a PID, the reaper couldn't verify if the Hermes child was still alive. Combined with the missing `hermes_local` entry in `SESSIONED_LOCAL_ADAPTERS` (separate Paperclip PR), any Hermes run exceeding 5 minutes was falsely declared `process_lost`.

## Verified

Live on ao-sh-derper: every historical Hermes run (including the successful 39-second AUT-19 run from 2026-04-23) showed `process_pid = NULL`.

## Related

- Sister fix: add `hermes_local` to `SESSIONED_LOCAL_ADAPTERS` in paperclipai/paperclip (separate PR)
- Paperclip issue: AIW-185