### PR TITLE
fix: enrich hermes local usage from state db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -24,6 +24,12 @@ import type {
   UsageSummary,
 } from "@paperclipai/adapter-utils";
 
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
 import {
   runChildProcess,
   buildPaperclipEnv,
@@ -205,12 +211,145 @@ const TOKEN_USAGE_REGEX =
 /** Regex to extract cost from Hermes output. */
 const COST_REGEX = /(?:cost|spent)[:\s]*\$?([\d.]+)/i;
 
+const execFileAsync = promisify(execFile);
+
 interface ParsedOutput {
   sessionId?: string;
   response?: string;
   usage?: UsageSummary;
   costUsd?: number;
   errorMessage?: string;
+}
+
+interface HermesSessionUsage {
+  usage: UsageSummary;
+  costUsd?: number;
+  provider?: string;
+  model?: string;
+  billingType?: "api" | "subscription" | "metered_api" | "subscription_included" | "subscription_overage" | "credits" | "fixed" | "unknown";
+  details: Record<string, unknown>;
+}
+
+function resolveHermesHome(
+  env: Record<string, string | undefined>,
+  config: Record<string, unknown>,
+): string {
+  return (
+    cfgString(config.hermesHome) ||
+    env.HERMES_HOME ||
+    join(homedir(), ".hermes")
+  );
+}
+
+function billingTypeFromMode(mode: string | null | undefined): HermesSessionUsage["billingType"] {
+  if (!mode) return "unknown";
+  if (mode === "api_key" || mode === "api") return "api";
+  if (mode === "subscription") return "subscription";
+  return "unknown";
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Read Hermes' authoritative per-session usage/cost data from state.db.
+ *
+ * Hermes quiet output only exposes a session_id. Current Paperclip accounting
+ * needs AdapterExecutionResult.usage/costUsd to be populated by the adapter, so
+ * the local adapter joins the session_id back to Hermes' SQLite state store.
+ * This is best-effort: missing sqlite/python/state.db must never fail the run.
+ */
+export async function readHermesSessionUsage(
+  sessionId: string | undefined,
+  env: Record<string, string | undefined>,
+  config: Record<string, unknown>,
+): Promise<HermesSessionUsage | null> {
+  if (!sessionId) return null;
+
+  const stateDb = join(resolveHermesHome(env, config), "state.db");
+  if (!existsSync(stateDb)) return null;
+
+  const sql = `
+import json, sqlite3, sys
+session_id = sys.argv[1]
+db_path = sys.argv[2]
+con = sqlite3.connect(db_path)
+con.row_factory = sqlite3.Row
+row = con.execute("""
+select
+  id,
+  model,
+  input_tokens,
+  output_tokens,
+  cache_read_tokens,
+  cache_write_tokens,
+  reasoning_tokens,
+  billing_provider,
+  billing_mode,
+  estimated_cost_usd,
+  actual_cost_usd,
+  cost_status,
+  cost_source,
+  pricing_version,
+  api_call_count
+from sessions
+where id = ?
+limit 1
+""", (session_id,)).fetchone()
+con.close()
+print(json.dumps(dict(row) if row else None))
+`;
+
+  try {
+    const { stdout } = await execFileAsync("python3", ["-c", sql, sessionId, stateDb], {
+      timeout: 5000,
+      maxBuffer: 64 * 1024,
+    });
+    const row = JSON.parse(stdout.trim()) as Record<string, unknown> | null;
+    if (!row) return null;
+
+    const inputTokens = Number(row.input_tokens) || 0;
+    const outputTokens = Number(row.output_tokens) || 0;
+    const cachedInputTokens = Number(row.cache_read_tokens) || 0;
+    const actualCost = nullableNumber(row.actual_cost_usd);
+    const estimatedCost = nullableNumber(row.estimated_cost_usd);
+    const costUsd = actualCost !== null && actualCost > 0
+      ? actualCost
+      : estimatedCost !== null
+        ? estimatedCost
+        : undefined;
+
+    return {
+      usage: {
+        inputTokens,
+        outputTokens,
+        ...(cachedInputTokens > 0 ? { cachedInputTokens } : {}),
+      },
+      ...(costUsd !== undefined ? { costUsd } : {}),
+      provider: typeof row.billing_provider === "string" ? row.billing_provider : undefined,
+      model: typeof row.model === "string" ? row.model : undefined,
+      billingType: billingTypeFromMode(typeof row.billing_mode === "string" ? row.billing_mode : undefined),
+      details: {
+        usage_source: "hermes_state_db",
+        session_id: sessionId,
+        cache_write_tokens: Number(row.cache_write_tokens) || 0,
+        reasoning_tokens: Number(row.reasoning_tokens) || 0,
+        billing_provider: row.billing_provider ?? null,
+        billing_mode: row.billing_mode ?? null,
+        estimated_cost_usd: estimatedCost,
+        actual_cost_usd: actualCost,
+        cost_status: row.cost_status ?? null,
+        cost_source: row.cost_source ?? null,
+        pricing_version: row.pricing_version ?? null,
+        api_call_count: Number(row.api_call_count) || 0,
+      },
+    };
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -480,6 +619,10 @@ export async function execute(
 
   // ── Parse output ───────────────────────────────────────────────────────
   const parsed = parseHermesOutput(result.stdout || "", result.stderr || "");
+  const hermesUsage = await readHermesSessionUsage(parsed.sessionId, env, config);
+  if (hermesUsage) {
+    await ctx.onLog("stdout", "[hermes] Usage loaded from Hermes state.db\n");
+  }
 
   await ctx.onLog(
     "stdout",
@@ -494,20 +637,24 @@ export async function execute(
     exitCode: result.exitCode,
     signal: result.signal,
     timedOut: result.timedOut,
-    provider: resolvedProvider,
-    model,
+    provider: hermesUsage?.provider || resolvedProvider,
+    model: hermesUsage?.model || model,
   };
+
+  if (hermesUsage?.billingType) {
+    executionResult.billingType = hermesUsage.billingType;
+  }
 
   if (parsed.errorMessage) {
     executionResult.errorMessage = parsed.errorMessage;
   }
 
-  if (parsed.usage) {
-    executionResult.usage = parsed.usage;
+  if (hermesUsage?.usage || parsed.usage) {
+    executionResult.usage = hermesUsage?.usage || parsed.usage;
   }
 
-  if (parsed.costUsd !== undefined) {
-    executionResult.costUsd = parsed.costUsd;
+  if (hermesUsage?.costUsd !== undefined || parsed.costUsd !== undefined) {
+    executionResult.costUsd = hermesUsage?.costUsd ?? parsed.costUsd;
   }
 
   // Summary from agent response
@@ -515,12 +662,16 @@ export async function execute(
     executionResult.summary = parsed.response.slice(0, 2000);
   }
 
+  const resultJsonUsage = hermesUsage?.usage || parsed.usage || null;
+  const resultJsonCostUsd = hermesUsage?.costUsd ?? parsed.costUsd ?? null;
+
   // Set resultJson so Paperclip can persist run metadata (used for UI display + auto-comments)
   executionResult.resultJson = {
     result: parsed.response || "",
     session_id: parsed.sessionId || null,
-    usage: parsed.usage || null,
-    cost_usd: parsed.costUsd ?? null,
+    usage: resultJsonUsage,
+    cost_usd: resultJsonCostUsd,
+    ...(hermesUsage ? { hermes_usage: hermesUsage.details } : {}),
   };
 
   // Store session ID for next run

--- a/test/hermes-state-usage.test.mjs
+++ b/test/hermes-state-usage.test.mjs
@@ -1,0 +1,144 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import { readHermesSessionUsage } from '../dist/server/execute.js';
+
+function createHermesHome(row) {
+  const dir = mkdtempSync(join(tmpdir(), 'hermes-state-'));
+  const dbPath = join(dir, 'state.db');
+  const sql = `
+create table sessions (
+  id text primary key,
+  source text not null,
+  model text,
+  input_tokens integer default 0,
+  output_tokens integer default 0,
+  cache_read_tokens integer default 0,
+  cache_write_tokens integer default 0,
+  reasoning_tokens integer default 0,
+  billing_provider text,
+  billing_mode text,
+  estimated_cost_usd real,
+  actual_cost_usd real,
+  cost_status text,
+  cost_source text,
+  pricing_version text,
+  api_call_count integer default 0
+);
+insert into sessions (
+  id, source, model, input_tokens, output_tokens, cache_read_tokens,
+  cache_write_tokens, reasoning_tokens, billing_provider, billing_mode,
+  estimated_cost_usd, actual_cost_usd, cost_status, cost_source,
+  pricing_version, api_call_count
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+`;
+  execFileSync('python3', ['-c', `
+import json, sqlite3, sys
+sql = sys.stdin.read()
+create_sql, insert_sql = sql.split(';', 1)
+con=sqlite3.connect(sys.argv[1])
+values=json.loads(sys.argv[2])
+con.execute(create_sql + ';')
+con.execute(insert_sql, values)
+con.commit()
+con.close()
+`, dbPath, JSON.stringify([
+    row.id,
+    'tool',
+    row.model,
+    row.input_tokens,
+    row.output_tokens,
+    row.cache_read_tokens,
+    row.cache_write_tokens,
+    row.reasoning_tokens,
+    row.billing_provider,
+    row.billing_mode,
+    row.estimated_cost_usd,
+    row.actual_cost_usd,
+    row.cost_status,
+    row.cost_source,
+    row.pricing_version,
+    row.api_call_count,
+  ])], { input: sql });
+  return dir;
+}
+
+test('reads Hermes session usage from HERMES_HOME/state.db', async () => {
+  const hermesHome = createHermesHome({
+    id: 'sess_123',
+    model: 'openai/gpt-5.4-mini',
+    input_tokens: 1234,
+    output_tokens: 56,
+    cache_read_tokens: 789,
+    cache_write_tokens: 12,
+    reasoning_tokens: 34,
+    billing_provider: 'openrouter',
+    billing_mode: 'api_key',
+    estimated_cost_usd: 0.0123,
+    actual_cost_usd: 0.0456,
+    cost_status: 'actual',
+    cost_source: 'provider',
+    pricing_version: 'test-pricing',
+    api_call_count: 2,
+  });
+  try {
+    const usage = await readHermesSessionUsage('sess_123', { HERMES_HOME: hermesHome }, {});
+    assert.deepEqual(usage?.usage, {
+      inputTokens: 1234,
+      cachedInputTokens: 789,
+      outputTokens: 56,
+    });
+    assert.equal(usage?.costUsd, 0.0456);
+    assert.equal(usage?.provider, 'openrouter');
+    assert.equal(usage?.model, 'openai/gpt-5.4-mini');
+    assert.equal(usage?.details.usage_source, 'hermes_state_db');
+    assert.equal(usage?.details.cache_write_tokens, 12);
+    assert.equal(usage?.details.reasoning_tokens, 34);
+    assert.equal(usage?.details.api_call_count, 2);
+  } finally {
+    rmSync(hermesHome, { recursive: true, force: true });
+  }
+});
+
+test('uses estimated cost and preserves null actual cost when provider actual is unavailable', async () => {
+  const hermesHome = createHermesHome({
+    id: 'sess_estimated',
+    model: 'openai/gpt-5.4-mini',
+    input_tokens: 438,
+    output_tokens: 31,
+    cache_read_tokens: 9216,
+    cache_write_tokens: 0,
+    reasoning_tokens: 0,
+    billing_provider: 'openrouter',
+    billing_mode: null,
+    estimated_cost_usd: 0.0011592,
+    actual_cost_usd: null,
+    cost_status: 'estimated',
+    cost_source: 'provider_models_api',
+    pricing_version: null,
+    api_call_count: 1,
+  });
+  try {
+    const usage = await readHermesSessionUsage('sess_estimated', { HERMES_HOME: hermesHome }, {});
+    assert.equal(usage?.costUsd, 0.0011592);
+    assert.equal(usage?.details.actual_cost_usd, null);
+    assert.equal(usage?.details.estimated_cost_usd, 0.0011592);
+    assert.equal(usage?.billingType, 'unknown');
+  } finally {
+    rmSync(hermesHome, { recursive: true, force: true });
+  }
+});
+
+test('returns null instead of throwing when state.db is missing', async () => {
+  const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-state-missing-'));
+  try {
+    const usage = await readHermesSessionUsage('sess_missing', { HERMES_HOME: hermesHome }, {});
+    assert.equal(usage, null);
+  } finally {
+    rmSync(hermesHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- enriches hermes_local execution results with Hermes session usage from `$HERMES_HOME/state.db`
- preserves the existing stdout/stderr usage parser as a fallback
- records diagnostic `resultJson.hermes_usage` metadata while populating Paperclip `usage`, `costUsd`, provider, model, and billing type when available

## Why
Hermes quiet CLI output currently exposes the answer and `session_id`, but not a stable machine-readable usage/cost block. Paperclip only persists run accounting when the adapter returns `usage` and/or `costUsd`, so hermes_local runs were showing `usageJson: null` and zero spend despite Hermes recording token/cost data in its own state DB.

## Safety / compatibility
- best-effort only: missing state DB, missing session row, missing `python3`/sqlite, or query errors return `null` and do not fail the Hermes run
- falls back to the existing Hermes stdout/stderr parser
- no Paperclip core schema changes
- no secrets are read or logged
- uses `config.hermesHome`, then `HERMES_HOME`, then `~/.hermes`

## Tests
- `npm run typecheck`
- `npm run build`
- `node --test test/*.test.mjs`

`npm run lint` is not currently runnable in this checkout because `eslint` is not installed/listed as a dev dependency.

## Lab evidence
Verified in an isolated Paperclip/Hermes lab with no production Hermes home or production `.env` mounted into the container.

Final smoke run:
- Run ID: `e57a355b-4666-4314-90dd-80f97486b632`
- Hermes session: `20260502_005214_d854d5`
- status: `succeeded`
- `usageJson`: non-null
- `resultJson.cost_usd`: `0.0011862`
- `resultJson.hermes_usage.usage_source`: `hermes_state_db`
- `hermesCostStatus`: `estimated`
- `actual_cost_usd`: `null`
- provider/biller: `openrouter`
- model: `openai/gpt-5.4-mini`

Observed usage in Paperclip after the patch:
- input tokens: `438`
- output tokens: `37`
- cached input tokens: `9216`
- cost USD: `0.0011862`
