### PR TITLE
fix: normalize configured env values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test tests/*.test.mjs",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -63,6 +63,27 @@ function cfgStringArray(v: unknown): string[] | undefined {
     : undefined;
 }
 
+export function resolveEnvValue(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record.value === "string") return record.value;
+    if (typeof record.plain === "string") return record.plain;
+  }
+  return undefined;
+}
+
+export function applyConfiguredEnv(
+  env: Record<string, string>,
+  userEnv: Record<string, unknown> | undefined,
+): void {
+  if (!userEnv || typeof userEnv !== "object") return;
+  for (const [key, value] of Object.entries(userEnv)) {
+    const resolved = resolveEnvValue(value);
+    if (resolved !== undefined) env[key] = resolved;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
 // ---------------------------------------------------------------------------
@@ -420,10 +441,7 @@ export async function execute(
   const taskId = cfgString(ctx.config?.taskId);
   if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
-  const userEnv = config.env as Record<string, string> | undefined;
-  if (userEnv && typeof userEnv === "object") {
-    Object.assign(env, userEnv);
-  }
+  applyConfiguredEnv(env, config.env as Record<string, unknown> | undefined);
 
   // ── Resolve working directory ──────────────────────────────────────────
   const cwd =

--- a/tests/execute-env.test.mjs
+++ b/tests/execute-env.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { applyConfiguredEnv, resolveEnvValue } from '../dist/server/execute.js';
+
+test('resolveEnvValue passes through plain strings', () => {
+  assert.equal(resolveEnvValue('/tmp/hermes'), '/tmp/hermes');
+});
+
+test('resolveEnvValue unwraps Paperclip plain env objects', () => {
+  assert.equal(
+    resolveEnvValue({ type: 'plain', value: '/home/doug/.hermes/profiles/researcher' }),
+    '/home/doug/.hermes/profiles/researcher',
+  );
+});
+
+test('resolveEnvValue unwraps legacy plain-shaped objects', () => {
+  assert.equal(resolveEnvValue({ plain: '/tmp/legacy-home' }), '/tmp/legacy-home');
+});
+
+test('applyConfiguredEnv overlays only resolved string values', () => {
+  const env = { EXISTING: '1' };
+  applyConfiguredEnv(env, {
+    HERMES_HOME: { type: 'plain', value: '/home/doug/.hermes/profiles/researcher' },
+    PAPERCLIP_RUN_ID: 'abc123',
+    DROP_ME: { type: 'secret' },
+  });
+  assert.deepEqual(env, {
+    EXISTING: '1',
+    HERMES_HOME: '/home/doug/.hermes/profiles/researcher',
+    PAPERCLIP_RUN_ID: 'abc123',
+  });
+});


### PR DESCRIPTION
## Summary
- normalize configured env entries before merging into the spawned child-process environment
- unwrap string values from Paperclip-style env objects such as `{ value: "..." }` and `{ plain: "..." }`
- ignore unresolved non-string objects instead of coercing them to `[object Object]`
- add regression tests covering both value-shape variants and overlay behavior

## Problem
Paperclip can hand adapter env settings to the Hermes adapter as typed objects rather than raw strings. The adapter was doing a blind merge into `process.env`, which coerced those objects to `[object Object]`. That breaks runtime settings like `HERMES_HOME`, API URLs, and similar path/token values before Hermes even starts.

## Test Plan
- [x] `npm test`

## Notes
This keeps the fix narrow and backward-compatible:
- raw strings still pass through unchanged
- supported wrapper object shapes are unwrapped
- unknown object shapes are ignored rather than stringified
