### PR TITLE
fix: export hermes paperclip adapter factory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,14 @@
  */
 
 import { ADAPTER_TYPE, ADAPTER_LABEL } from "./shared/constants.js";
+import {
+  detectModel as detectHermesModel,
+  execute,
+  testEnvironment,
+  listSkills,
+  syncSkills,
+  sessionCodec,
+} from "./server/index.js";
 
 export const type = ADAPTER_TYPE;
 export const label = ADAPTER_LABEL;
@@ -82,3 +90,21 @@ tools, persistent memory, session persistence, skills, and MCP support.
 - \`{{taskBody}}\` — Task description (if assigned)
 - \`{{projectName}}\` — Project name (if scoped to a project)
 `;
+
+export function createServerAdapter() {
+  return {
+    type,
+    execute,
+    testEnvironment,
+    listSkills,
+    syncSkills,
+    sessionCodec,
+    detectModel: () => detectHermesModel(),
+    models,
+    agentConfigurationDoc,
+    supportsLocalAgentJwt: true,
+    supportsInstructionsBundle: true,
+    instructionsPathKey: "instructionsFilePath",
+    requiresMaterializedRuntimeSkills: false,
+  };
+}


### PR DESCRIPTION
Exports createServerAdapter() from the Hermes Paperclip adapter so Paperclip can load the external adapter again. Also wires execute/testEnvironment/session handling through the adapter factory and keeps the adapter capability flags explicit.

Verification:
- npm run build
- node -e "import('./dist/index.js').then(m=>{const a=m.createServerAdapter(); console.log(a.type, typeof a.execute, typeof a.testEnvironment, typeof a.detectModel, a.supportsLocalAgentJwt)})"
- paperclipai run --no-repair
- GET /api/health => status ok