### PR TITLE
fix: v0.2.1 회귀 수정 — || → ?? 연산자, model 기본값 제거

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -35,7 +35,6 @@ import {
   HERMES_CLI,
   DEFAULT_TIMEOUT_SEC,
   DEFAULT_GRACE_SEC,
-  DEFAULT_MODEL,
   VALID_PROVIDERS,
 } from "../shared/constants.js";
 
@@ -316,9 +315,9 @@ export async function execute(
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
-  const model = cfgString(config.model) || DEFAULT_MODEL;
-  const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
-  const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
+  const model = cfgString(config.model);
+  const timeoutSec = cfgNumber(config.timeoutSec) ?? DEFAULT_TIMEOUT_SEC;
+  const graceSec = cfgNumber(config.graceSec) ?? DEFAULT_GRACE_SEC;
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
   const extraArgs = cfgStringArray(config.extraArgs);


### PR DESCRIPTION
## 요약

`v0.2.1`에서 `v0.2.0`에 적용되었던 중요 수정사항 2가지가 되돌려진 회귀(regression)를 수정합니다.

## 변경 내용

### 1. `||` → `??` 연산자 변경 (timeoutSec, graceSec)

```typescript
// 수정 전 (v0.2.1) — 0값이 falsy로 처리되어 기본값으로 강제됨
const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;  // 0 → 1800초
const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;        // 0 → 10초

// 수정 후 — 0값을 유효한 설정값으로 인식
const timeoutSec = cfgNumber(config.timeoutSec) ?? DEFAULT_TIMEOUT_SEC;
const graceSec = cfgNumber(config.graceSec) ?? DEFAULT_GRACE_SEC;
```

### 2. model 기본값 제거

```typescript
// 수정 전 (v0.2.1) — Hermes 자체 설정을 무시하고 anthropic/claude-sonnet-4로 강제
const model = cfgString(config.model) || DEFAULT_MODEL;

// 수정 후 — 모델 미설정 시 Hermes 자체 설정 사용
const model = cfgString(config.model);
```

## 영향

- `timeoutSec=0` 설정 시 의도한 무제한 타임아웃이 적용됨
- `graceSec=0` 설정 시 의도한 유예기간 없음이 적용됨
- 모델 미지정 시 Hermes의 `~/.hermes/config.yaml` 설정을 따름

## 관련

- [SUA-1014](/SUA/issues/SUA-1014)
- [SUA-1084](/SUA/issues/SUA-1084)