### PR TITLE
fix(execute): anchor SESSION_ID_REGEX_LEGACY so it stops capturing 'from'

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -195,8 +195,17 @@ function buildPrompt(
 /** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
 const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
 
-/** Regex for legacy session output format */
-const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
+/**
+ * Regex for legacy session output format.
+ *
+ * Anchored to start-of-line + multiline so it only matches a true session
+ * announcement at the beginning of a line. Without `^\s*` and the `m` flag,
+ * the pattern false-matches inside the error message
+ *   "Use a session ID from a previous CLI run"
+ * capturing the literal word "from" as a session ID and corrupting state.
+ */
+const SESSION_ID_REGEX_LEGACY =
+  /^\s*session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/im;
 
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =

--- a/src/server/session-id-regex.test.mjs
+++ b/src/server/session-id-regex.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * Regression test for the legacy session-ID regex.
+ *
+ * The unanchored pattern false-matched the literal word "from" inside the
+ * error message "Use a session ID from a previous CLI run", corrupting
+ * downstream session state. Anchoring to start-of-line + multiline mode
+ * fixes it.
+ *
+ * Plain ESM + node:test so this file runs without TS tooling:
+ *   node --test src/server/session-id-regex.test.mjs
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const SESSION_ID_REGEX_LEGACY =
+  /^\s*session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/im;
+
+test("does not capture 'from' inside the helper error message", () => {
+  const stderr =
+    "Session not found: from\nUse a session ID from a previous CLI run";
+  const match = stderr.match(SESSION_ID_REGEX_LEGACY);
+  assert.equal(match, null);
+});
+
+test("captures a real legacy 'session_id: <id>' line", () => {
+  const stdout = "session_id: 01J9X2PQRSTUVWXYZ_abc";
+  const match = stdout.match(SESSION_ID_REGEX_LEGACY);
+  assert.equal(match?.[1], "01J9X2PQRSTUVWXYZ_abc");
+});
+
+test("captures 'session saved: <id>' on its own line", () => {
+  const stdout = "noise\nsession saved: 01J9X2PQRSTUVWXYZ_abc\nmore";
+  const match = stdout.match(SESSION_ID_REGEX_LEGACY);
+  assert.equal(match?.[1], "01J9X2PQRSTUVWXYZ_abc");
+});
+
+test("ignores 'session id' that appears mid-sentence", () => {
+  const stdout = "Use a session id from a previous CLI run";
+  const match = stdout.match(SESSION_ID_REGEX_LEGACY);
+  assert.equal(match, null);
+});


### PR DESCRIPTION
## Bug

`SESSION_ID_REGEX_LEGACY` is unanchored and case-insensitive, so it false-matches the literal word **`from`** inside the helper string the CLI itself prints when a session is missing:

```
Use a session ID from a previous CLI run
```

The legacy parser then captures `from` as a session ID, the adapter persists it, and the very next run tries to resume `from` — which of course does not exist — producing the user-visible error:

```
Session not found: from
```

The agent loop stalls there until state is overwritten by a real run.

## Reproducer

```js
"Session not found: from\nUse a session ID from a previous CLI run"
  .match(/session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i)?.[1]
// "from"   ← bug: should be undefined
```

## Fix

Anchor the pattern to start-of-line and add the `m` flag so matches are restricted to the leading position of a line — which is the only place a real Hermes session announcement is ever emitted:

```diff
-const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
+const SESSION_ID_REGEX_LEGACY =
+  /^\s*session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/im;
```

The fixed pattern still captures both `session_id: <id>` and `session saved: <id>` on their own line — only the false-match inside prose is dropped.

## Tests

Adds `src/server/session-id-regex.test.mjs` — plain ESM + `node:test` so it runs without TS tooling:

```
node --test src/server/session-id-regex.test.mjs
```

Pins the bug (must not capture `"from"`) plus three positive cases:

- captures real `session_id:` line
- captures `session saved:` line embedded in surrounding noise
- ignores mid-sentence `"session id"` references

All four pass with the new pattern; the first one fails on `main`.

## Context

Caught downstream in Paperclip — when the adapter ingested its own helper output as a session ID, every Hermes-driven loop produced a "Session not found: from" stall. Tracked there as PHA-711 (in-place mitigation) and PHA-714 (durability + this PR).

Single-file source change. No public API or behavioral change beyond the regex itself.