### PR TITLE
feat: read instruction files from managed directory and inject into agent prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -44,6 +44,9 @@ import {
   resolveProvider,
 } from "./detect-model.js";
 
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+
 // ---------------------------------------------------------------------------
 // Config helpers
 // ---------------------------------------------------------------------------
@@ -354,8 +357,56 @@ export async function execute(
     model,
   });
 
+  // ── Load instruction files from managed directory ──────────────────────
+  // Reads all .md files from the agent's managed instructions directory
+  // and prepends them to the prompt so agents actually receive their
+  // role-specific context. Without this, the per-agent AGENTS.md files
+  // visible in the Paperclip UI are never delivered to Hermes.
+  let instructionsPrefix = "";
+  const instructionsRoot =
+    cfgString(config.instructionsRootPath) ||
+    cfgString(config.instructionsFilePath);
+  if (instructionsRoot) {
+    // instructionsRootPath points to the directory; instructionsFilePath may point to a file
+    let dir = instructionsRoot;
+    if (path.extname(dir)) {
+      dir = path.dirname(dir);
+    }
+    try {
+      const files = await fsp.readdir(dir);
+      // Read entry file first (default: AGENTS.md), then others alphabetically
+      const entryFile = cfgString(config.instructionsEntryFile) || "AGENTS.md";
+      const prioritisedFiles = [
+        entryFile,
+        ...files.filter((f) => f !== entryFile && f.endsWith(".md")),
+      ];
+      const distinctFiles = [...new Set(prioritisedFiles)].filter((f) =>
+        f.endsWith(".md"),
+      );
+      const parts: string[] = [];
+      for (const file of distinctFiles) {
+        try {
+          const content = await fsp.readFile(path.join(dir, file), "utf-8");
+          if (content.trim()) {
+            parts.push(`# ${file}
+
+${content.trim()}`);
+          }
+        } catch {
+          /* file may not exist, skip */
+        }
+      }
+      if (parts.length > 0) {
+        instructionsPrefix = parts.join("\n\n---\n\n") + "\n\n---\n\n";
+      }
+    } catch {
+      /* directory may not exist yet, skip silently */
+    }
+  }
+
   // ── Build prompt ───────────────────────────────────────────────────────
-  const prompt = buildPrompt(ctx, config);
+  const basePrompt = buildPrompt(ctx, config);
+  const prompt = instructionsPrefix + basePrompt;
 
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line


### PR DESCRIPTION
## Problem

The hermes-paperclip-adapter completely ignores instruction files configured per agent in Paperclip. The adapter config includes `instructionsRootPath`, `instructionsFilePath`, and `instructionsEntryFile` fields — these are populated by the Paperclip server, visible in the Paperclip UI's Instructions pane, but never read or passed to the Hermes agent.

This means editing instruction files in the Paperclip UI has **no effect** on agent behaviour. The agent only receives the `promptTemplate` text, missing all role-specific context (AGENTS.md, heartbeat.md, TOOLS.md, etc.).

## Fix

The `execute()` function now:

1. Reads `instructionsRootPath` or `instructionsFilePath` from the agent's `adapterConfig`
2. If the path is a file, uses its directory
3. Lists all `.md` files, prioritising the entry file (`instructionsEntryFile`, default: `AGENTS.md`)
4. Reads each file, concatenates with `# filename` headers and `---` separators
5. Prepends the instruction content to the prompt before passing to Hermes

## Testing

- Set up an agent with managed instructions in Paperclip
- Add AGENTS.md, heartbeat.md, and TOOLS.md in the Instructions pane
- Trigger a heartbeat — verify the agent receives the instruction content in its prompt
- Confirmed working on a Grove HR Paperclip instance with 11 agents, each receiving role-specific context

## Files Changed

- `src/server/execute.ts` — instruction file loading logic added before prompt build