### PR TITLE
fix(session-codec): validate session ID format in serialize/deserialize

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,31 +18,45 @@ function readNonEmptyString(value: unknown): string | null {
 }
 
 /**
+ * Hermes session IDs follow the format `YYYYMMDD_HHMMSS_<hex>`, e.g.
+ * `20260513_091310_fb8871`. Anything that does not match — such as the
+ * word `"from"` accidentally captured from error output — is rejected.
+ */
+const HERMES_SESSION_ID_RE = /^\d{8}_\d{6}_[a-f0-9]+$/;
+
+function readValidSessionId(value: unknown): string | null {
+  const s = readNonEmptyString(value);
+  if (!s || !HERMES_SESSION_ID_RE.test(s)) return null;
+  return s;
+}
+
+/**
  * Session codec for structured validation and migration of session parameters.
  *
  * Hermes Agent uses a single `sessionId` for cross-heartbeat session continuity
- * via the `--resume` CLI flag. The codec validates and normalizes this field.
+ * via the `--resume` CLI flag. The codec validates and normalizes this field,
+ * rejecting values that do not match the Hermes session ID format.
  */
 export const sessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
     const record = raw as Record<string, unknown>;
     const sessionId =
-      readNonEmptyString(record.sessionId) ??
-      readNonEmptyString(record.session_id);
+      readValidSessionId(record.sessionId) ??
+      readValidSessionId(record.session_id);
     if (!sessionId) return null;
     return { sessionId };
   },
   serialize(params: Record<string, unknown> | null) {
     if (!params) return null;
     const sessionId =
-      readNonEmptyString(params.sessionId) ??
-      readNonEmptyString(params.session_id);
+      readValidSessionId(params.sessionId) ??
+      readValidSessionId(params.session_id);
     if (!sessionId) return null;
     return { sessionId };
   },
   getDisplayId(params: Record<string, unknown> | null) {
     if (!params) return null;
-    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    return readValidSessionId(params.sessionId) ?? readValidSessionId(params.session_id);
   },
 };

--- a/src/server/session-codec.test.mjs
+++ b/src/server/session-codec.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * Regression tests for the session codec format validation.
+ *
+ * The codec must reject session IDs that do not match the Hermes format
+ * (`YYYYMMDD_HHMMSS_<hex>`). Without validation, false-captured strings
+ * like `"from"` (parsed from error output by the legacy regex) corrupt
+ * stored session state and stall the agent loop.
+ *
+ * Plain ESM + node:test — runs without TS tooling:
+ *   node --test src/server/session-codec.test.mjs
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Inline the validation regex (mirrors src/server/index.ts)
+const HERMES_SESSION_ID_RE = /^\d{8}_\d{6}_[a-f0-9]+$/;
+
+function readNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function readValidSessionId(value) {
+  const s = readNonEmptyString(value);
+  if (!s || !HERMES_SESSION_ID_RE.test(s)) return null;
+  return s;
+}
+
+// Minimal codec replica for testing
+const sessionCodec = {
+  deserialize(raw) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw))
+      return null;
+    const sessionId =
+      readValidSessionId(raw.sessionId) ??
+      readValidSessionId(raw.session_id);
+    if (!sessionId) return null;
+    return { sessionId };
+  },
+  serialize(params) {
+    if (!params) return null;
+    const sessionId =
+      readValidSessionId(params.sessionId) ??
+      readValidSessionId(params.session_id);
+    if (!sessionId) return null;
+    return { sessionId };
+  },
+};
+
+// ── serialize ──────────────────────────────────────────────────────────
+
+test("serialize: accepts a valid Hermes session ID", () => {
+  const result = sessionCodec.serialize({
+    sessionId: "20260513_091310_fb8871",
+  });
+  assert.deepStrictEqual(result, { sessionId: "20260513_091310_fb8871" });
+});
+
+test("serialize: rejects 'from' (false capture from error output)", () => {
+  const result = sessionCodec.serialize({ sessionId: "from" });
+  assert.equal(result, null);
+});
+
+test("serialize: rejects truncated session ID (missing hex hash)", () => {
+  const result = sessionCodec.serialize({
+    sessionId: "20260513_091310_",
+  });
+  assert.equal(result, null);
+});
+
+test("serialize: rejects empty string", () => {
+  assert.equal(sessionCodec.serialize({ sessionId: "" }), null);
+});
+
+test("serialize: rejects null params", () => {
+  assert.equal(sessionCodec.serialize(null), null);
+});
+
+// ── deserialize ────────────────────────────────────────────────────────
+
+test("deserialize: accepts a valid session from JSONB object", () => {
+  const result = sessionCodec.deserialize({
+    sessionId: "20260512_125545_8aeee7",
+  });
+  assert.deepStrictEqual(result, { sessionId: "20260512_125545_8aeee7" });
+});
+
+test("deserialize: rejects 'from' in stored JSONB", () => {
+  const result = sessionCodec.deserialize({ sessionId: "from" });
+  assert.equal(result, null);
+});
+
+test("deserialize: rejects non-object input", () => {
+  assert.equal(sessionCodec.deserialize("20260513_091310_fb8871"), null);
+  assert.equal(sessionCodec.deserialize(null), null);
+  assert.equal(sessionCodec.deserialize(42), null);
+});
+
+test("deserialize: reads session_id key (snake_case fallback)", () => {
+  const result = sessionCodec.deserialize({
+    session_id: "20260513_084138_197de3",
+  });
+  assert.deepStrictEqual(result, { sessionId: "20260513_084138_197de3" });
+});
+
+test("deserialize: rejects garbage in snake_case key too", () => {
+  const result = sessionCodec.deserialize({ session_id: "from" });
+  assert.equal(result, null);
+});


### PR DESCRIPTION
## What does this PR do?

Adds format validation to the `sessionCodec` in `src/server/index.ts`. The codec currently accepts any non-empty string as a session ID — including the word `"from"`, which is false-captured from Hermes error output by `SESSION_ID_REGEX_LEGACY`. Once stored, the corrupted value poisons `--resume` on every subsequent run, creating an unrecoverable agent stall.

This is a **defense-in-depth complement** to #112 (regex anchoring). Even if a future output format fools the regex, the codec rejects invalid values at the storage boundary before they reach the database.

## Related Issue

Complements #112 — that PR anchors the regex to prevent the false capture; this PR validates at the codec layer so no garbage can be persisted regardless of how it was parsed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `src/server/index.ts` — Added `HERMES_SESSION_ID_RE` (`/^\d{8}_\d{6}_[a-f0-9]+$/`) and `readValidSessionId()` helper. Both `serialize()` and `deserialize()` now validate session IDs match the Hermes `YYYYMMDD_HHMMSS_hex` format before accepting them. Non-matching values (e.g. `"from"`, truncated IDs like `"20260513_091310_"`, empty strings) return `null`.
- `src/server/session-codec.test.mjs` — 10 regression tests covering both serialize and deserialize: valid IDs accepted, `"from"` rejected, truncated IDs rejected, empty/null handling, snake_case key fallback.

## How to Test

```bash
node --test src/server/session-codec.test.mjs
```

All 10 tests pass. To reproduce the original bug without this fix:

```js
// The legacy regex false-captures "from" from error help text
"Use a session ID from a previous CLI run"
  .match(/session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i)?.[1]
// → "from"

// Without codec validation, this gets stored and poisons --resume:
sessionCodec.serialize({ sessionId: "from" })
// Before: { sessionId: "from" }  ← stored, breaks next run
// After:  null                    ← rejected at boundary
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(session-codec):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-paperclip-adapter/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes (10 test cases in `session-codec.test.mjs`)
- [x] I've tested on my platform: Scaleway Kapsule (K8s v1.34.6, Node.js v24.15.0, Paperclip v2026.428.0)
- [x] `tsc --noEmit` passes with zero errors

### Documentation & Housekeeping

- [x] No config keys added/changed — N/A
- [x] No architecture changes — N/A
- [x] Cross-platform: pure regex + string validation, no platform-specific code — N/A

## Context

Discovered in production on a Paperclip instance running 7 Hermes agents (4 `claude_local` + 3 `hermes_local`). When any Hermes run failed, the legacy regex captured `"from"` from the error help text `"Use a session ID from a previous CLI run"`. The codec stored it without validation. Every subsequent run tried `--resume from`, failed instantly with `"Session not found: from"`, re-captured `"from"` from the new error output, and the loop never broke. Two of three Hermes agents were stuck in this state. Claude agents on the same instance were unaffected (different adapter, different codec).

The regex anchoring in #112 prevents the specific false capture. This codec validation prevents the *class* of corruption — any non-Hermes-format string is rejected before it can poison stored state.