### PR TITLE
fix: use adapter env PAPERCLIP_API_URL when rendering Hermes prompt

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -62,6 +62,19 @@ function cfgStringArray(v: unknown): string[] | undefined {
     ? (v as string[])
     : undefined;
 }
+function cfgEnvString(v: unknown): string | undefined {
+  if (typeof v === "string" && v.length > 0) return v;
+  if (
+    v &&
+    typeof v === "object" &&
+    "value" in v &&
+    typeof (v as { value?: unknown }).value === "string" &&
+    (v as { value: string }).value.length > 0
+  ) {
+    return (v as { value: string }).value;
+  }
+  return undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Wake-up prompt builder
@@ -325,6 +338,7 @@ export async function execute(
   const persistSession = cfgBoolean(config.persistSession) !== false;
   const worktreeMode = cfgBoolean(config.worktreeMode) === true;
   const checkpoints = cfgBoolean(config.checkpoints) === true;
+  const userEnv = config.env as Record<string, unknown> | undefined;
 
   // ── Resolve provider (defense in depth) ────────────────────────────────
   // Priority chain:
@@ -355,7 +369,14 @@ export async function execute(
   });
 
   // ── Build prompt ───────────────────────────────────────────────────────
-  const prompt = buildPrompt(ctx, config);
+  const promptConfig: Record<string, unknown> = { ...config };
+  if (!cfgString(promptConfig.paperclipApiUrl) && userEnv && typeof userEnv === "object") {
+    const configuredPaperclipApiUrl = cfgEnvString(userEnv.PAPERCLIP_API_URL);
+    if (configuredPaperclipApiUrl) {
+      promptConfig.paperclipApiUrl = configuredPaperclipApiUrl;
+    }
+  }
+  const prompt = buildPrompt(ctx, promptConfig);
 
   // ── Build command args ─────────────────────────────────────────────────
   // Use -Q (quiet) to get clean output: just response + session_id line
@@ -420,9 +441,8 @@ export async function execute(
   const taskId = cfgString(ctx.config?.taskId);
   if (taskId) env.PAPERCLIP_TASK_ID = taskId;
 
-  const userEnv = config.env as Record<string, string> | undefined;
   if (userEnv && typeof userEnv === "object") {
-    Object.assign(env, userEnv);
+    Object.assign(env, userEnv as Record<string, string>);
   }
 
   // ── Resolve working directory ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Use `adapterConfig.env.PAPERCLIP_API_URL` when rendering the Hermes default prompt, unless `paperclipApiUrl` is explicitly configured.

Closes #117.

## Why

The adapter already passes `config.env` into the spawned Hermes process, but the prompt was rendered before those env overrides were considered.

That meant Hermes could receive:

```text
PAPERCLIP_API_URL=http://127.0.0.1:3100
```

while the prompt still instructed it to call:

```text
https://example-public-host/api
```

Agents tend to follow the prompt examples, so this can break authenticated or private deployments where the browser/public URL is not reachable from the worker runtime.

## Change

- Build a prompt config from the resolved adapter config
- If `paperclipApiUrl` is not explicitly set, read `PAPERCLIP_API_URL` from `config.env`
- Render the prompt with that derived value
- Preserve existing explicit `paperclipApiUrl` behavior

## Validation

- Built the adapter successfully
- Verified in a local Paperclip deployment with a fake Hermes command that the generated prompt contains the env-derived API base URL
- Verified the spawned environment still receives the same `PAPERCLIP_API_URL`
