### PR TITLE
Use Hermes profile defaults when model is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Create issues in Paperclip and assign them to your Hermes agent. On each heartbe
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `model` | string | `anthropic/claude-sonnet-4` | Model in `provider/model` format |
-| `provider` | string | *(auto-detected)* | API provider: `auto`, `openrouter`, `nous`, `openai-codex`, `zai`, `kimi-coding`, `minimax`, `minimax-cn` |
+| `model` | string | *(Hermes configured default)* | Optional explicit model in `provider/model` format. Leave blank to use Hermes's configured default model. |
+| `provider` | string | *(Hermes configured default / auto)* | Optional API provider override: `auto`, `openrouter`, `nous`, `openai-codex`, `zai`, `kimi-coding`, `minimax`, `minimax-cn` |
 | `timeoutSec` | number | `300` | Execution timeout in seconds |
 | `graceSec` | number | `10` | Grace period before SIGKILL |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-paperclip-adapter",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@paperclipai/adapter-utils": "^2026.325.0",

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -35,8 +35,6 @@ import {
   HERMES_CLI,
   DEFAULT_TIMEOUT_SEC,
   DEFAULT_GRACE_SEC,
-  DEFAULT_MODEL,
-  VALID_PROVIDERS,
 } from "../shared/constants.js";
 
 import {
@@ -61,6 +59,16 @@ function cfgStringArray(v: unknown): string[] | undefined {
   return Array.isArray(v) && v.every((i) => typeof i === "string")
     ? (v as string[])
     : undefined;
+}
+function cfgExtraArgs(v: unknown): string[] | undefined {
+  const values = cfgStringArray(v);
+  if (!values) return undefined;
+  return values.flatMap((value) =>
+    value
+      .split(/[\s,]+/)
+      .map((part) => part.trim())
+      .filter(Boolean),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -316,12 +324,12 @@ export async function execute(
 
   // ── Resolve configuration ──────────────────────────────────────────────
   const hermesCmd = cfgString(config.hermesCommand) || HERMES_CLI;
-  const model = cfgString(config.model) || DEFAULT_MODEL;
+  const model = cfgString(config.model);
   const timeoutSec = cfgNumber(config.timeoutSec) || DEFAULT_TIMEOUT_SEC;
   const graceSec = cfgNumber(config.graceSec) || DEFAULT_GRACE_SEC;
   const maxTurns = cfgNumber(config.maxTurnsPerRun);
   const toolsets = cfgString(config.toolsets) || cfgStringArray(config.enabledToolsets)?.join(",");
-  const extraArgs = cfgStringArray(config.extraArgs);
+  const extraArgs = cfgExtraArgs(config.extraArgs);
   const persistSession = cfgBoolean(config.persistSession) !== false;
   const worktreeMode = cfgBoolean(config.worktreeMode) === true;
   const checkpoints = cfgBoolean(config.checkpoints) === true;
@@ -336,23 +344,30 @@ export async function execute(
   // This ensures that even if the agent was created before provider tracking
   // was added, or if the model was changed without updating provider, the
   // correct provider is still used.
-  let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
+  let resolvedProvider = "auto";
+  let resolvedFrom = "hermesProfile";
   const explicitProvider = cfgString(config.provider);
 
-  if (!explicitProvider) {
-    try {
-      detectedConfig = await detectModel();
-    } catch {
-      // Non-fatal — detection failure shouldn't block execution
-    }
-  }
+  if (model || explicitProvider) {
+    let detectedConfig: Awaited<ReturnType<typeof detectModel>> | null = null;
 
-  const { provider: resolvedProvider, resolvedFrom } = resolveProvider({
-    explicitProvider,
-    detectedProvider: detectedConfig?.provider,
-    detectedModel: detectedConfig?.model,
-    model,
-  });
+    if (!explicitProvider) {
+      try {
+        detectedConfig = await detectModel();
+      } catch {
+        // Non-fatal — detection failure shouldn't block execution
+      }
+    }
+
+    const resolved = resolveProvider({
+      explicitProvider,
+      detectedProvider: detectedConfig?.provider,
+      detectedModel: detectedConfig?.model,
+      model,
+    });
+    resolvedProvider = resolved.provider;
+    resolvedFrom = resolved.resolvedFrom;
+  }
 
   // ── Build prompt ───────────────────────────────────────────────────────
   const prompt = buildPrompt(ctx, config);
@@ -437,7 +452,7 @@ export async function execute(
   // ── Log start ──────────────────────────────────────────────────────────
   await ctx.onLog(
     "stdout",
-    `[hermes] Starting Hermes Agent (model=${model}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
+    `[hermes] Starting Hermes Agent (model=${model ?? "Hermes profile default"}, provider=${resolvedProvider} [${resolvedFrom}], timeout=${timeoutSec}s${maxTurns ? `, max_turns=${maxTurns}` : ""})\n`,
   );
   if (prevSessionId) {
     await ctx.onLog(

--- a/src/ui/build-config.ts
+++ b/src/ui/build-config.ts
@@ -66,7 +66,7 @@ export function buildHermesConfig(
 
   // Extra CLI arguments
   if (v.extraArgs) {
-    ac.extraArgs = v.extraArgs.split(/\s+/).filter(Boolean);
+    ac.extraArgs = v.extraArgs.split(/[\s,]+/).filter(Boolean);
   }
 
   // Thinking/reasoning effort


### PR DESCRIPTION
## Summary
- do not inject the adapter default model when agent config omits model
- avoid resolving/passing provider unless model/provider is explicitly configured
- normalize extraArgs from UI/runtime with comma or whitespace separators so values like `--profile, ottobytebeaver` are split correctly
- update README defaults to document Hermes profile defaults

## Validation
- npm run build
