### PR TITLE
fix: harden Hermes session parsing and Grok provider routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test test/*.test.mjs",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -192,11 +192,20 @@ function buildPrompt(
 // Output parsing
 // ---------------------------------------------------------------------------
 
+const HERMES_SESSION_ID_PATTERN = "\\d{8}_\\d{6}_[a-fA-F0-9]+";
+
+function isValidHermesSessionId(value: string | undefined): value is string {
+  return typeof value === "string" && new RegExp(`^${HERMES_SESSION_ID_PATTERN}$`).test(value);
+}
+
 /** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
-const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
+const SESSION_ID_REGEX = new RegExp(`^session_id:\\s*(${HERMES_SESSION_ID_PATTERN})\\s*$`, "m");
 
 /** Regex for legacy session output format */
-const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
+const SESSION_ID_REGEX_LEGACY = new RegExp(
+  `session[_ ](?:id|saved)[:\\s]+(${HERMES_SESSION_ID_PATTERN})`,
+  "i",
+);
 
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
@@ -254,19 +263,21 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
   //   <response text>
   //
   //   session_id: <id>
-  const sessionMatch = stdout.match(SESSION_ID_REGEX);
-  if (sessionMatch?.[1]) {
-    result.sessionId = sessionMatch?.[1] ?? null;
-    // The response is everything before the session_id line
-    const sessionLineIdx = stdout.lastIndexOf("\nsession_id:");
-    if (sessionLineIdx > 0) {
-      result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
-    }
+  const sessionMatch = combined.match(SESSION_ID_REGEX);
+  if (isValidHermesSessionId(sessionMatch?.[1])) {
+    result.sessionId = sessionMatch[1];
+  }
+
+  // Response text always comes from stdout. In quiet mode Hermes may emit the
+  // canonical session line on stderr, so never use its stream location to
+  // decide whether stdout should be cleaned.
+  const sessionLineIdx = stdout.lastIndexOf("\nsession_id:");
+  if (sessionLineIdx > 0) {
+    result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
   } else {
-    // Legacy format (non-quiet mode)
     const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
-    if (legacyMatch?.[1]) {
-      result.sessionId = legacyMatch?.[1] ?? null;
+    if (!result.sessionId && isValidHermesSessionId(legacyMatch?.[1])) {
+      result.sessionId = legacyMatch[1];
     }
     // In non-quiet mode, extract clean response from stdout by
     // filtering out tool lines, system messages, and noise
@@ -397,9 +408,10 @@ export async function execute(
   args.push("--yolo");
 
   // Session resume
-  const prevSessionId = cfgString(
+  const rawSessionId = cfgString(
     (ctx.runtime?.sessionParams as Record<string, unknown> | null)?.sessionId,
   );
+  const prevSessionId = isValidHermesSessionId(rawSessionId) ? rawSessionId : undefined;
   if (persistSession && prevSessionId) {
     args.push("--resume", prevSessionId);
   }
@@ -485,8 +497,12 @@ export async function execute(
     "stdout",
     `[hermes] Exit code: ${result.exitCode ?? "null"}, timed out: ${result.timedOut}\n`,
   );
-  if (parsed.sessionId) {
-    await ctx.onLog("stdout", `[hermes] Session: ${parsed.sessionId}\n`);
+  const parsedSessionId = result.exitCode === 0 && isValidHermesSessionId(parsed.sessionId)
+    ? parsed.sessionId
+    : undefined;
+
+  if (parsedSessionId) {
+    await ctx.onLog("stdout", `[hermes] Session: ${parsedSessionId}\n`);
   }
 
   // ── Build result ───────────────────────────────────────────────────────
@@ -518,15 +534,15 @@ export async function execute(
   // Set resultJson so Paperclip can persist run metadata (used for UI display + auto-comments)
   executionResult.resultJson = {
     result: parsed.response || "",
-    session_id: parsed.sessionId || null,
+    session_id: parsedSessionId || null,
     usage: parsed.usage || null,
     cost_usd: parsed.costUsd ?? null,
   };
 
   // Store session ID for next run
-  if (persistSession && parsed.sessionId) {
-    executionResult.sessionParams = { sessionId: parsed.sessionId };
-    executionResult.sessionDisplayId = parsed.sessionId.slice(0, 16);
+  if (persistSession && parsedSessionId) {
+    executionResult.sessionParams = { sessionId: parsedSessionId };
+    executionResult.sessionDisplayId = parsedSessionId;
   }
 
   return executionResult;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,6 +38,8 @@ export const VALID_PROVIDERS = [
   "minimax",
   "minimax-cn",
   "kilocode",
+  "xai",
+  "xai-oauth",
 ] as const;
 
 /**
@@ -68,6 +70,9 @@ export const MODEL_PREFIX_PROVIDER_HINTS: [string, string][] = [
   ["kimi", "kimi-coding"],
   // MiniMax
   ["minimax", "minimax"],
+  // xAI / Grok
+  ["grok-", "xai-oauth"],
+  ["grok/", "xai-oauth"],
   // DeepSeek
   ["deepseek", "auto"],
   // Meta Llama

--- a/test/execute-session.test.mjs
+++ b/test/execute-session.test.mjs
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { execute } from "../dist/server/execute.js";
+
+async function makeFakeHermesCommand() {
+  const dir = await mkdtemp(join(tmpdir(), "hermes-adapter-test-"));
+  const command = join(dir, "fake-hermes.mjs");
+  await writeFile(
+    command,
+    `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+if (process.env.HERMES_FAKE_ARGV_FILE) {
+  writeFileSync(process.env.HERMES_FAKE_ARGV_FILE, JSON.stringify(process.argv.slice(2), null, 2));
+}
+if (process.env.HERMES_FAKE_STDOUT) process.stdout.write(process.env.HERMES_FAKE_STDOUT);
+if (process.env.HERMES_FAKE_STDERR) process.stderr.write(process.env.HERMES_FAKE_STDERR);
+process.exit(Number(process.env.HERMES_FAKE_EXIT_CODE || "0"));
+`,
+    "utf8",
+  );
+  await chmod(command, 0o755);
+  return command;
+}
+
+function makeContext(config = {}, runtime = {}) {
+  const logs = [];
+  return {
+    runId: "run-test",
+    config,
+    runtime,
+    agent: {
+      id: "agent-test",
+      name: "Hermes Test Agent",
+      companyId: "company-test",
+      adapterConfig: {},
+    },
+    onLog: async (stream, chunk) => {
+      logs.push({ stream, chunk });
+    },
+    logs,
+  };
+}
+
+test("execute preserves the full Hermes session id as the display id", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const sessionId = "20260518_175454_0af855";
+  const ctx = makeContext({
+    hermesCommand,
+    model: "gpt-5.5",
+    env: {
+      HERMES_FAKE_STDOUT: `Agent finished.\n\nsession_id: ${sessionId}\n`,
+    },
+  });
+
+  const result = await execute(ctx);
+
+  assert.deepEqual(result.sessionParams, { sessionId });
+  assert.equal(result.sessionDisplayId, sessionId);
+  assert.equal(result.resultJson?.session_id, sessionId);
+});
+
+test("execute captures the canonical session id from quiet-mode stderr", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const sessionId = "20260518_175454_0af855";
+  const ctx = makeContext({
+    hermesCommand,
+    model: "gpt-5.5",
+    env: {
+      HERMES_FAKE_STDOUT: "Agent finished.\n",
+      HERMES_FAKE_STDERR: `session_id: ${sessionId}\n`,
+    },
+  });
+
+  const result = await execute(ctx);
+
+  assert.deepEqual(result.sessionParams, { sessionId });
+  assert.equal(result.sessionDisplayId, sessionId);
+  assert.equal(result.resultJson?.session_id, sessionId);
+  assert.equal(result.summary, "Agent finished.");
+});
+
+test("execute ignores invalid session ids parsed from Hermes error/help output", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const ctx = makeContext({
+    hermesCommand,
+    model: "gpt-5.5",
+    env: {
+      HERMES_FAKE_STDERR:
+        "Session not found: from\nUse a session ID from a previous CLI run (hermes sessions list).\n",
+      HERMES_FAKE_EXIT_CODE: "1",
+    },
+  });
+
+  const result = await execute(ctx);
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.sessionParams, undefined);
+  assert.equal(result.sessionDisplayId, undefined);
+  assert.equal(result.resultJson?.session_id, null);
+});
+
+test("execute does not pass invalid persisted session ids to --resume", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const dir = await mkdtemp(join(tmpdir(), "hermes-adapter-argv-"));
+  const argvFile = join(dir, "argv.json");
+  const sessionId = "20260518_175454_0af855";
+  const ctx = makeContext(
+    {
+      hermesCommand,
+      model: "gpt-5.5",
+      env: {
+        HERMES_FAKE_ARGV_FILE: argvFile,
+        HERMES_FAKE_STDOUT: `Recovered.\n\nsession_id: ${sessionId}\n`,
+      },
+    },
+    { sessionParams: { sessionId: "from" } },
+  );
+
+  const result = await execute(ctx);
+  const argv = JSON.parse(await readFile(argvFile, "utf8"));
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.sessionParams?.sessionId, sessionId);
+  assert.equal(argv.includes("--resume"), false);
+  assert.equal(argv.includes("from"), false);
+});

--- a/test/provider-resolution.test.mjs
+++ b/test/provider-resolution.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { VALID_PROVIDERS } from "../dist/shared/constants.js";
+import { inferProviderFromModel, resolveProvider } from "../dist/server/detect-model.js";
+
+test("xAI/Grok providers are valid explicit Hermes providers", () => {
+  assert.equal(VALID_PROVIDERS.includes("xai"), true);
+  assert.equal(VALID_PROVIDERS.includes("xai-oauth"), true);
+  assert.deepEqual(resolveProvider({ explicitProvider: "xai-oauth", model: "grok-4.3" }), {
+    provider: "xai-oauth",
+    resolvedFrom: "adapterConfig",
+  });
+});
+
+test("Grok model names infer xai-oauth instead of falling back to auto", () => {
+  assert.equal(inferProviderFromModel("grok-4.3"), "xai-oauth");
+  assert.equal(inferProviderFromModel("grok/grok-4.3"), "xai-oauth");
+  assert.deepEqual(resolveProvider({ model: "grok-4.3" }), {
+    provider: "xai-oauth",
+    resolvedFrom: "modelInference",
+  });
+});


### PR DESCRIPTION
## Summary

This PR contains two focused, independently reviewable commits for Hermes–Paperclip adapter failures:

1. `fix(adapter): harden Hermes session resume handling`
   - Accepts only canonical `YYYYMMDD_HHMMSS_<hex>` Hermes session IDs.
   - Reads canonical quiet-mode `session_id:` output from stdout or stderr while preserving stdout response text when metadata is on stderr.
   - Rejects invalid persisted IDs before adding `--resume`.
   - Persists session state only after a successful Hermes exit.
   - Preserves the full session ID in `sessionDisplayId`.
2. `fix(provider): route Grok models to xAI OAuth`
   - Adds `xai` and `xai-oauth` as valid providers.
   - Resolves `grok-*` and `grok/...` model names to `xai-oauth`.

Closes #75.
Closes #125.
Closes #127.

## Relevance and overlap

The fixes are still required on current `main`:

- `src/server/execute.ts` still accepts the permissive legacy session-ID pattern and truncates `sessionDisplayId` to 16 characters.
- `src/shared/constants.ts` still lacks xAI providers and Grok routing.
- No merged adapter PR provides these changes.
- #138 and #149 remain open and cover only subsets of the session fix. #149 removes display-ID truncation; #138 addresses failed-run persistence and permissive parsing. This PR covers both paths, validates already-persisted resume IDs, preserves quiet-mode stderr capture, and includes the separate Grok routing commit.
- Paperclip core PR paperclipai/paperclip#7516 merged host-side defenses and explicitly leaves adapter-side parsing for a separate fix. It complements rather than supersedes this PR.

## Verification

Latest local results on Fedora Linux:

```text
npm ci
npm test
# 6 tests passed, 0 failed

npm run typecheck
# passed

npm run build
# passed
```

Regression coverage verifies:

- full session IDs are retained;
- canonical IDs emitted on quiet-mode stderr are captured without dropping the assistant response;
- error prose cannot become a session ID;
- invalid stored IDs are not passed to `--resume`;
- `xai` / `xai-oauth` are accepted;
- Grok model names resolve to `xai-oauth`.

`npm run lint` remains unavailable on current `main`: after installing ESLint 9.39.4, the script stops because the repository ships no `eslint.config.*`. A temporary TypeScript-ESLint recommended audit found the same 15 pre-existing `execute.ts` findings on `main` and this branch, with no new findings in the changed tests or constants file. This PR does not add unrelated lint infrastructure.

## Risks

- Session validation is deliberately Hermes-specific. A future Hermes session-ID format change would require updating the pattern.
- Grok inference applies only when no explicit provider overrides it.
- No runtime dependency changes.

## Commit structure

The branch has exactly two substantive commits: one for session continuity and one for provider routing. The new stderr regression coverage is fixed up into the session commit; there are no follow-up repair commits.

