### PR TITLE
fix(server): read task context from ctx.context.* instead of ctx.config.* in buildPrompt

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -129,14 +129,14 @@ function buildPrompt(
 ): string {
   const template = cfgString(config.promptTemplate) || DEFAULT_PROMPT_TEMPLATE;
 
-  const taskId = cfgString(ctx.config?.taskId);
-  const taskTitle = cfgString(ctx.config?.taskTitle) || "";
-  const taskBody = cfgString(ctx.config?.taskBody) || "";
-  const commentId = cfgString(ctx.config?.commentId) || "";
-  const wakeReason = cfgString(ctx.config?.wakeReason) || "";
+  const taskId = cfgString(ctx.context?.taskId);
+  const taskTitle = cfgString(ctx.context?.taskTitle) || "";
+  const taskBody = cfgString(ctx.context?.taskBody) || "";
+  const commentId = cfgString(ctx.context?.commentId) || "";
+  const wakeReason = cfgString(ctx.context?.wakeReason) || "";
   const agentName = ctx.agent?.name || "Hermes Agent";
-  const companyName = cfgString(ctx.config?.companyName) || "";
-  const projectName = cfgString(ctx.config?.projectName) || "";
+  const companyName = cfgString(ctx.context?.companyName) || "";
+  const projectName = cfgString(ctx.context?.projectName) || "";
 
   // Build API URL — ensure it has the /api path
   let paperclipApiUrl =


### PR DESCRIPTION
## Thinking Path

> - hermes-paperclip-adapter bridges Hermes Agent into Paperclip companies
> - buildPrompt() reads task context fields (taskId, taskTitle, taskBody, commentId, wakeReason, companyName, projectName) from ctx.config.* but current Paperclip writes them at ctx.context.*
> - This means the prompt template receives empty/null values for all context fields, degrading task awareness
> - This matters because agents cannot reference their assigned task details, leading to unhelpful or generic responses
> - This PR changes all 7 context field reads from ctx.config.* to ctx.context.*
> - The benefit is that agents receive proper task context in their prompts

## What Changed

- src/server/execute.ts: Changed buildPrompt() to read taskId, taskTitle, taskBody, commentId, wakeReason, companyName, projectName from ctx.context.* instead of ctx.config.* (addresses upstream #132)

## Verification

- CI: typecheck + build green on isak-ialogics fork
- Command: npx tsc --noEmit
- Output: (clean, exit code 0)

## Risks

- Low risk — isolated change, only affects which object path context fields are read from

## Model

- Provider: Nous Research Hermes Agent v0.15.1
- Model: qwen/qwen3.6-35b-a3b (Q8_0, 35B MoE, 128k context)
- Infrastructure: LM Studio on local GPU via hermes_local adapter