### PR TITLE
fix(server): remove 16-char truncation on sessionDisplayId

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -526,7 +526,7 @@ export async function execute(
   // Store session ID for next run
   if (persistSession && parsed.sessionId) {
     executionResult.sessionParams = { sessionId: parsed.sessionId };
-    executionResult.sessionDisplayId = parsed.sessionId.slice(0, 16);
+    executionResult.sessionDisplayId = parsed.sessionId;
   }
 
   return executionResult;


### PR DESCRIPTION
## Thinking Path

> - hermes-paperclip-adapter bridges Hermes Agent into Paperclip companies
> - The adapter truncates sessionDisplayId to the first 16 characters of the session ID
> - Hermes session IDs are 22 chars (YYYYMMDD_HHMMSS_<hex>); truncating to 16 chars cuts off the hex suffix
> - The stored sessionDisplayId is no longer a valid session ID, breaking session continuity
> - This PR removes the truncation and stores the full session ID
> - The benefit is proper session resume across runs

## What Changed

- `src/server/execute.ts`: Removed .slice(0, 16) from sessionDisplayId assignment. Stores the full session ID.

## Verification

- CI: typecheck + build green on isak-ialogics fork
- Command: npx tsc --noEmit
- Output: clean, exit code 0
- After fix: sessionDisplayId contains the full 22-char session ID

## Risks

- Low risk — isolated single-line change. The session ID is only used for display/resume; storing the full ID is strictly better.

## Model

- Provider: Nous Research Hermes Agent v0.15.1
- Model: qwen/qwen3.6-35b-a3b (Q8_0, 35B MoE, 128k context)
- Infrastructure: LM Studio on local GPU via hermes_local adapter