### PR TITLE
fix(server): add xAI/Grok provider to VALID_PROVIDERS and MODEL_PREFIX_PROVIDER_HINTS

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,6 +38,7 @@ export const VALID_PROVIDERS = [
   "minimax",
   "minimax-cn",
   "kilocode",
+  "xai",
 ] as const;
 
 /**
@@ -76,6 +77,8 @@ export const MODEL_PREFIX_PROVIDER_HINTS: [string, string][] = [
   ["qwen", "auto"],
   // Mistral
   ["mistral", "auto"],
+  // xAI / Grok
+  ["grok", "xai"],
   // HuggingFace models (org/model format)
   ["huggingface/", "huggingface"],
 ];


### PR DESCRIPTION
## Thinking Path

> - hermes-paperclip-adapter bridges Hermes Agent into Paperclip companies
> - The xAI/Grok provider is missing from VALID_PROVIDERS and MODEL_PREFIX_PROVIDER_HINTS
> - Users with Grok models cannot use the adapter without custom config overrides
> - This matters because it's a basic provider registration gap — other providers (OpenAI, Anthropic, etc.) are all listed
> - This PR adds "xai" to VALID_PROVIDERS and ["grok", "xai"] to MODEL_PREFIX_PROVIDER_HINTS
> - The benefit is users can use Grok models out of the box

## What Changed

- `src/shared/constants.ts`: Added "xai" to VALID_PROVIDERS array
- `src/shared/constants.ts`: Added ["grok", "xai"] entry to MODEL_PREFIX_PROVIDER_HINTS so model strings like "grok-2" or "grok-3" are correctly resolved to the xai provider

## Verification

- CI: typecheck + build green on isak-ialogics fork
- Command: npx tsc --noEmit
- Output: clean (no errors)
- Command: npm run build
- Output: clean (no errors)

## Risks

- Low risk — isolated change to constants array, no logic changes

## Model

- Provider: Nous Research Hermes Agent v0.15.1
- Model: qwen/qwen3.6-35b-a3b (Q8_0, 35B MoE, 128k context)
- Infrastructure: LM Studio on local GPU via hermes_local adapter