### PR TITLE
fix(server): add createServerAdapter() export - breaks paperclipai drop-in adapter install

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,14 @@
  * Server-side adapter module exports.
  */
 
+import type {
+  AdapterModel,
+  AdapterSessionCodec,
+  ServerAdapterModule,
+} from "@paperclipai/adapter-utils";
+
+import { ADAPTER_TYPE, ADAPTER_LABEL } from "../shared/constants.js";
+
 export { execute } from "./execute.js";
 export { testEnvironment } from "./test.js";
 export { detectModel, parseModelFromConfig, resolveProvider, inferProviderFromModel } from "./detect-model.js";
@@ -11,7 +19,13 @@ export {
   resolveHermesDesiredSkillNames as resolveDesiredSkillNames,
 } from "./skills.js";
 
-import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+// Local imports for createServerAdapter()
+import { execute } from "./execute.js";
+import { testEnvironment } from "./test.js";
+import {
+  listHermesSkills as listSkills,
+  syncHermesSkills as syncSkills,
+} from "./skills.js";
 
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
@@ -46,3 +60,78 @@ export const sessionCodec: AdapterSessionCodec = {
     return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
   },
 };
+
+/**
+ * Build and return a ServerAdapterModule for the Hermes Agent adapter.
+ *
+ * This is the primary entry point for Paperclip's adapter loader. Call
+ * createServerAdapter() from your server code to obtain a fully assembled
+ * ServerAdapterModule that Paperclip can register and invoke.
+ */
+export function createServerAdapter(): ServerAdapterModule {
+  return {
+    type: ADAPTER_TYPE,
+    execute,
+    testEnvironment,
+    listSkills,
+    syncSkills,
+    sessionCodec,
+    models: [] as AdapterModel[],
+    agentConfigurationDoc: `# ${ADAPTER_LABEL} Configuration
+
+${ADAPTER_LABEL} is a full-featured AI agent by Nous Research with 30+ native
+tools, persistent memory, session persistence, skills, and MCP support.
+
+## Prerequisites
+
+- Python 3.10+ installed
+- ${ADAPTER_LABEL} installed: \`pip install hermes-agent\`
+- At least one LLM API key configured in ~/.hermes/.env
+
+## Core Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| model | string | (Hermes configured default) | Optional explicit model in provider/model format. Leave blank to use Hermes's configured default model. |
+| provider | string | (auto) | API provider: auto, openrouter, nous, openai-codex, zai, kimi-coding, minimax, minimax-cn. Usually not needed — Hermes auto-detects from model name. |
+| timeoutSec | number | 300 | Execution timeout in seconds |
+| graceSec | number | 10 | Grace period after SIGTERM before SIGKILL |
+
+## Tool Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| toolsets | string | (all) | Comma-separated toolsets to enable (e.g. "terminal,file,web") |
+
+## Session & Workspace
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| persistSession | boolean | true | Resume sessions across heartbeats |
+| worktreeMode | boolean | false | Use git worktree for isolated changes |
+| checkpoints | boolean | false | Enable filesystem checkpoints |
+
+## Advanced
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| hermesCommand | string | hermes | Path to hermes CLI binary |
+| verbose | boolean | false | Enable verbose output |
+| extraArgs | string[] | [] | Additional CLI arguments |
+| env | object | {} | Extra environment variables |
+| promptTemplate | string | (default) | Custom prompt template with {{variable}} placeholders |
+
+## Available Template Variables
+
+- \`{{agentId}}\` — Paperclip agent ID
+- \`{{agentName}}\` — Agent display name
+- \`{{companyId}}\` — Paperclip company ID
+- \`{{companyName}}\` — Company display name
+- \`{{runId}}\` — Current heartbeat run ID
+- \`{{taskId}}\` — Current task/issue ID (if assigned)
+- \`{{taskTitle}}\` — Task title (if assigned)
+- \`{{taskBody}}\` — Task description (if assigned)
+- \`{{projectName}}\` — Project name (if scoped to a project)
+`,
+  };
+}


### PR DESCRIPTION
## Thinking path

Fork PR #7 on isak-ialogics/hermes-paperclip-adapter implements the fix.
Upstream issue: https://github.com/NousResearch/hermes-paperclip-adapter/issues/64

## What changed

- src/server/index.ts — added createServerAdapter() export returning a complete ServerAdapterModule

## Why

Paperclip's plugin loader (plugin-loader.js) expects createServerAdapter() to be exported from the package main entry. Without it, users who install via Settings -> Adapters -> Install get a 500 error:
"Package does not export createServerAdapter()"

## Verification

- CI green on fork: typecheck + build + lint all pass
- Diff touches 1 file (within 3-file limit)
- Additive change — does not break existing manual-registry install path

## Risks

None. This is purely an additive export. The existing registry.set() install path is unaffected.