### PR TITLE
fix(server): forward ctx.onSpawn to runChildProcess so processPid is recorded

### DIFF
--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -476,6 +476,7 @@ export async function execute(
     timeoutSec,
     graceSec,
     onLog: wrappedOnLog,
+    onSpawn: ctx.onSpawn,
   });
 
   // ── Parse output ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- src/server/execute.ts: Forward ctx.onSpawn to runChildProcess so processPid is recorded

## Verification
- Command: Run a hermes agent via Paperclip on any issue
- Output: processPid is properly recorded in the session

## Uncertainty flags
None

## Model
qwen/qwen3.6-35b-a3b via hermes_local on LM Studio