### PR TITLE
fix(execute): reject malformed prevSessionId before --resume (RUAAAAA-1977)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-paperclip-adapter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,8 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run"
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "^2026.325.0",
@@ -39,7 +40,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -195,8 +195,47 @@ function buildPrompt(
 /** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
 const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
 
-/** Regex for legacy session output format */
-const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
+/** Canonical Hermes session id shape: yyyyMMdd_HHmmss_<hex>. */
+const HERMES_SESSION_ID_SHAPE = /^\d{8}_\d{6}_[a-f0-9]+$/;
+
+/** Common English words that must never be treated as session ids. They leak
+ *  into the capture group when the legacy regex matches CLI help text such as
+ *  "Use a session ID from a previous CLI run" (see RUAAAAA-1977 / 2033). */
+const SESSION_ID_STOPWORDS: ReadonlySet<string> = new Set([
+  "from", "with", "for", "to", "in", "of", "on", "at", "by", "an", "a", "the",
+  "is", "it", "as", "or", "and", "use", "list", "previous", "cli", "run",
+  "session", "id", "saved", "please",
+]);
+
+/** Regex for legacy session output format. Tightened to require either a
+ *  colon/equals-delimited key (e.g. `session_id: <id>`, `session saved: <id>`,
+ *  `session_id=<id>`) or a leading line prefix like `[hermes]`, `[resume]`,
+ *  `Session saved:`. The capture group is also post-validated by
+ *  isPlausibleSessionId() which enforces the canonical shape and rejects
+ *  English stopwords. Exported for the regression test in
+ *  test/parseHermesOutput.test.ts. */
+export const SESSION_ID_REGEX_LEGACY =
+  /(?:^|\s)(?:\[(?:hermes|resume|paperclip)\]\s*)?(?:session[_ ](?:id|saved)\s*[:=]\s*)([a-zA-Z0-9_-]+)/i;
+
+/** Returns true when a candidate session id is structurally plausible:
+ *  matches the canonical Hermes shape AND is not a single common English
+ *  word. Defends against the legacy regex matching CLI help text and
+ *  capturing the literal word `from`. */
+export function isPlausibleSessionId(candidate: unknown): candidate is string {
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    return false;
+  }
+  if (HERMES_SESSION_ID_SHAPE.test(candidate)) {
+    return true;
+  }
+  if (/^[a-z]+$/.test(candidate) && SESSION_ID_STOPWORDS.has(candidate)) {
+    return false;
+  }
+  // Any other shape is rejected by default — the adapter only ever expects
+  // canonical Hermes session ids. Defense in depth: refuse unknown shapes
+  // rather than pass them to `hermes resume` and risk a runaway loop.
+  return false;
+}
 
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
@@ -211,6 +250,7 @@ interface ParsedOutput {
   usage?: UsageSummary;
   costUsd?: number;
   errorMessage?: string;
+  warnings?: Array<{ kind: string; [k: string]: unknown }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,8 +305,19 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
   } else {
     // Legacy format (non-quiet mode)
     const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
-    if (legacyMatch?.[1]) {
-      result.sessionId = legacyMatch?.[1] ?? null;
+    if (legacyMatch?.[1] && isPlausibleSessionId(legacyMatch[1])) {
+      result.sessionId = legacyMatch[1];
+    } else if (legacyMatch?.[1]) {
+      // The legacy regex captured a value that fails the strict shape
+      // check. Surface it as a warning so the misclassification is
+      // observable in the run log. Do NOT persist it as sessionId.
+      result.sessionId = undefined;
+      result.warnings = (result.warnings ?? []);
+      result.warnings.push({
+        kind: "session_id_rejected",
+        captured: legacyMatch[1],
+        reason: "failed_canonical_shape_check",
+      });
     }
     // In non-quiet mode, extract clean response from stdout by
     // filtering out tool lines, system messages, and noise
@@ -397,9 +448,25 @@ export async function execute(
   args.push("--yolo");
 
   // Session resume
-  const prevSessionId = cfgString(
+  // Defense in depth: even if a previous run persisted a malformed
+  // prevSessionId (e.g. the literal "from" captured from CLI help text, or
+  // a truncated suffix like "20260619_110651_"), refuse to pass it to
+  // `hermes resume`. Drop --resume and start fresh; emit a structured
+  // warning so the misclassification is observable.
+  const rawPrevSessionId = cfgString(
     (ctx.runtime?.sessionParams as Record<string, unknown> | null)?.sessionId,
   );
+  const prevSessionId = isPlausibleSessionId(rawPrevSessionId)
+    ? rawPrevSessionId
+    : undefined;
+  if (rawPrevSessionId && !prevSessionId && ctx.runtime?.sessionParams) {
+    // Surface the rejection in the structured env so downstream tooling
+    // can correlate this run with the originating wake payload.
+    (ctx.runtime.sessionParams as Record<string, unknown>).resumeRejected = {
+      captured: rawPrevSessionId,
+      reason: "failed_canonical_shape_check_at_resume_guard",
+    };
+  }
   if (persistSession && prevSessionId) {
     args.push("--resume", prevSessionId);
   }
@@ -443,6 +510,11 @@ export async function execute(
     await ctx.onLog(
       "stdout",
       `[hermes] Resuming session: ${prevSessionId}\n`,
+    );
+  } else if (rawPrevSessionId) {
+    await ctx.onLog(
+      "stdout",
+      `[hermes] Skipping --resume: rejected prevSessionId=${rawPrevSessionId} (failed canonical shape check; starting fresh)\n`,
     );
   }
 

--- a/test/parseHermesOutput.test.ts
+++ b/test/parseHermesOutput.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression test for RUAAAAA-1977 / RUAAAAA-2033 / RUAAAAA-2035:
+ *   The legacy SESSION_ID_REGEX in hermes-paperclip-adapter@0.2.0 used to
+ *   match the Hermes CLI help text "Use a session ID from a previous CLI run"
+ *   and capture the literal word `from` as a session id. That bogus id was
+ *   then re-fed to `hermes resume` on every subsequent run, generating a
+ *   runaway adapter_failed loop that stranded the assigned issue.
+ *
+ * These tests assert the fix: any captured id must pass the canonical
+ * Hermes shape check (^\d{8}_\d{6}_[a-f0-9]+$) OR be rejected by
+ * isPlausibleSessionId(). No English stopword may ever be persisted as a
+ * session id, and no malformed prevSessionId may reach `hermes resume`.
+ *
+ * Originally authored as a zero-dependency node:test harness in the
+ * in-place dist patch (RUAAAAA-2033, file test/parseHermesOutput.test.js);
+ * ported to vitest + TypeScript here so it runs in CI upstream and tests
+ * the real exported helper instead of the eval-from-dist hack.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isPlausibleSessionId, SESSION_ID_REGEX_LEGACY } from "../src/server/execute.js";
+
+/** Inlined copy of the legacy parse branch — the only branch that ever
+ *  produced the bug. Stays in lockstep with parseHermesOutput() in
+ *  src/server/execute.ts. */
+function parseLegacySessionId(combined: string): {
+  sessionId: string | undefined;
+  warning: { kind: string; captured: string; reason: string } | null;
+} {
+  const m = combined.match(SESSION_ID_REGEX_LEGACY);
+  if (!m?.[1]) return { sessionId: undefined, warning: null };
+  if (isPlausibleSessionId(m[1])) return { sessionId: m[1], warning: null };
+  return {
+    sessionId: undefined,
+    warning: {
+      kind: "session_id_rejected",
+      captured: m[1],
+      reason: "failed_canonical_shape_check",
+    },
+  };
+}
+
+/** Stopwords mirror of SESSION_ID_STOPWORDS in src/server/execute.ts. Used
+ *  to drive the sweep test without exporting the constant. */
+const SESSION_ID_STOPWORDS = new Set([
+  "from", "with", "for", "to", "in", "of", "on", "at", "by", "an", "a", "the",
+  "is", "it", "as", "or", "and", "use", "list", "previous", "cli", "run",
+  "session", "id", "saved", "please",
+]);
+
+describe("RUAAAAA-1977 regression: parseHermesOutput legacy session id", () => {
+  it("rejects the literal word `from` leaked from the Hermes CLI help text", () => {
+    // Exact stderr string observed on RUAAAAA-1960 (run fffeda20, 2026-06-19).
+    // The pre-fix SESSION_ID_REGEX_LEGACY matched the phrase
+    //   "Use a session ID from a previous CLI run"
+    // and captured the literal word `from`. The fix tightens the regex to
+    // require a colon/equals-delimited key, so the help text no longer
+    // matches at all. Result: no capture, no sessionId, no warning.
+    const stderr = [
+      "[hermes] Resuming session: from",
+      "Session not found: from",
+      "Use a session ID from a previous CLI run (hermes sessions list).",
+      "[hermes] Exit code: 1",
+    ].join("\n");
+    const r = parseLegacySessionId("\n" + stderr);
+    expect(r.sessionId).toBeUndefined();
+    // Verify the legacy regex no longer matches the help text. If the
+    // regex is ever loosened again, this test will fail loudly.
+    expect(
+      SESSION_ID_REGEX_LEGACY.test(
+        "Use a session ID from a previous CLI run (hermes sessions list).",
+      ),
+    ).toBe(false);
+  });
+
+  it("emits a session_id_rejected warning when the regex matches a non-canonical value", () => {
+    // A hypothetical run where stdout contains a literal `session_id: from`
+    // — this could only happen if a previous run already corrupted the
+    // sessionParams. The fix path is: regex matches, but the captured value
+    // fails the canonical shape check, so the warning fires and sessionId
+    // is dropped.
+    const combined = "session_id: from";
+    const r = parseLegacySessionId(combined);
+    expect(r.sessionId).toBeUndefined();
+    expect(r.warning).not.toBeNull();
+    expect(r.warning?.kind).toBe("session_id_rejected");
+    expect(r.warning?.captured).toBe("from");
+    expect(r.warning?.reason).toBe("failed_canonical_shape_check");
+  });
+
+  it("accepts a real canonical session id `20260619_110651_dea627`", () => {
+    const combined = [
+      "Some Hermes response text here.",
+      "",
+      "session_id: 20260619_110651_dea627",
+    ].join("\n");
+    const r = parseLegacySessionId(combined);
+    expect(r.sessionId).toBe("20260619_110651_dea627");
+    expect(r.warning).toBeNull();
+  });
+
+  it("rejects the truncated suffix `20260619_110651_` observed on RUAAAAA-1960 run 5e599a1b", () => {
+    // The literal captured value when the legacy regex matched
+    // `session_id: 20260619_110651_` (suffix stripped by an earlier bug).
+    const combined = "session_id: 20260619_110651_";
+    const r = parseLegacySessionId(combined);
+    expect(r.sessionId).toBeUndefined();
+    expect(r.warning).not.toBeNull();
+    expect(r.warning?.captured).toBe("20260619_110651_");
+  });
+
+  it("rejects every English stopword that could leak from CLI help text", () => {
+    for (const word of SESSION_ID_STOPWORDS) {
+      expect(
+        isPlausibleSessionId(word),
+        `stopword '${word}' must be rejected as a session id`,
+      ).toBe(false);
+    }
+  });
+
+  it("rejects non-string, empty, and clearly-malformed inputs", () => {
+    expect(isPlausibleSessionId(undefined)).toBe(false);
+    expect(isPlausibleSessionId("")).toBe(false);
+    expect(isPlausibleSessionId(null)).toBe(false);
+    expect(isPlausibleSessionId(42)).toBe(false);
+    // Looks session-ish but is the wrong shape: must be refused.
+    expect(isPlausibleSessionId("not-a-real-id")).toBe(false);
+    expect(isPlausibleSessionId("20260619_110651_GARBAGE")).toBe(false);
+  });
+
+  it("accepts every character of a real canonical id, not just the prefix", () => {
+    expect(isPlausibleSessionId("20260619_110651_dea627")).toBe(true);
+    expect(isPlausibleSessionId("20260619_110651_a")).toBe(true);
+    // The first 12 chars of a real id are NOT a valid id by themselves.
+    expect(
+      isPlausibleSessionId("20260619_110651"),
+      "truncated prefix (no _<hex> suffix) must be rejected",
+    ).toBe(false);
+  });
+});
+
+describe("RUAAAAA-1977 regression: --resume runtime guard contract", () => {
+  // The guard logic is exercised in the integration path, but its contract is
+  // "any non-plausible prevSessionId is dropped before args.push('--resume', ...)".
+  // That contract is equivalent to: prevSessionIdUsedInArgs === isPlausibleSessionId(prevSessionId)
+  // so we just exercise the predicate on the exact values observed in the wild.
+  it("rejects every value that previously reached `hermes resume`", () => {
+    const observed = [
+      "from",                          // fffeda20, 4230e814, 565d5395, 55afbfbc, 2026-06-14 set
+      "20260619_110651_",              // 5e599a1b (truncated)
+      "20260614_165932_",              // 2026-06-14 set
+      "20260614_170614_",              // 2026-06-14 set
+    ];
+    for (const v of observed) {
+      expect(
+        isPlausibleSessionId(v),
+        `historical bad id '${v}' must now be rejected by the resume guard`,
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What

Ports the three-layer fix from RUAAAAA-2033 (the in-place dist patch on the running Paperclip server) to the upstream TypeScript source.

## Why

SESSION_ID_REGEX_LEGACY in src/server/execute.ts matched the Hermes CLI help text 'Use a session ID from a previous CLI run' and captured the literal word \`from\` as a session id. That bogus id was then re-fed to \`hermes resume\` on every subsequent run, generating a runaway adapter_failed loop that stranded the assigned issue. The dist patch on the running Paperclip server fixes the immediate bug, but lives in the pnpm content-addressable store — a future \`pnpm install\` would overwrite it.

## Three-layer fix

- Layer 1 — tighten SESSION_ID_REGEX_LEGACY to require a colon/equals-delimited key (e.g. \`session_id: <id>\`, \`session_id=<id>\`) or a leading \`[hermes]\`/\`[resume]\`/\`[paperclip]\` line prefix.
- Layer 2 — add HERMES_SESSION_ID_SHAPE + SESSION_ID_STOPWORDS + isPlausibleSessionId() type guard. Non-canonical captures are dropped with a session_id_rejected warning instead of being persisted.
- Layer 3 — runtime guard before \`--resume\` that drops any persisted bad prevSessionId and starts fresh, with structured \`[hermes] Skipping --resume: rejected prevSessionId=...\` log line and resumeRejected annotation on ctx.runtime.sessionParams.

## Tests

- Adds vitest as a devDependency and a \`test\` script.
- test/parseHermesOutput.test.ts — 8 regression assertions, ported from the in-place JS test, including the literal \`from\`-from-CLI-help case, the truncated-suffix case, the stopword sweep, and the historical-bad-id sweep from the observed wild runs (fffeda20, 4230e814, 565d5395, 55afbfbc, 5e599a1b, and the 2026-06-14 set).
- All 8 tests pass locally (vitest run).
- \`pnpm typecheck\` and \`pnpm build\` are clean. The freshly-built dist/server/execute.js contains the fix; the PR is a clean drop-in for ^0.3.1.

## Version

Bumped 0.3.0 -> 0.3.1 (semver patch on top of current main). Note: the issue acceptance text referenced \`0.2.1\`, but no \`0.2.1\` was ever published to npm — the published \`0.2.0\` is two minor versions behind the current main, so the correct semver bump is \`0.3.1\`. The Paperclip server can be moved off the in-place dist patch as soon as \`0.3.1\` is published.

## References

- RUAAAAA-1977 — original bug ticket (closed)
- RUAAAAA-2033 — in-place dist patch (closed); this PR is the durability follow-up
- RUAAAAA-2035 — this issue

cc @NousResearch maintainers — would appreciate eyes on whether \`0.2.1\` was reserved for an unrelated release. If so, happy to retarget the bump.