### PR TITLE
fix(adapter): harden Hermes session resume handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "tsc --watch",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test test/*.test.mjs",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/src/server/execute.ts
+++ b/src/server/execute.ts
@@ -192,11 +192,20 @@ function buildPrompt(
 // Output parsing
 // ---------------------------------------------------------------------------
 
+const HERMES_SESSION_ID_PATTERN = "\\d{8}_\\d{6}_[a-fA-F0-9]+";
+
+function isValidHermesSessionId(value: string | undefined): value is string {
+  return typeof value === "string" && new RegExp(`^${HERMES_SESSION_ID_PATTERN}$`).test(value);
+}
+
 /** Regex to extract session ID from Hermes quiet-mode output: "session_id: <id>" */
-const SESSION_ID_REGEX = /^session_id:\s*(\S+)/m;
+const SESSION_ID_REGEX = new RegExp(`^session_id:\\s*(${HERMES_SESSION_ID_PATTERN})\\s*$`, "m");
 
 /** Regex for legacy session output format */
-const SESSION_ID_REGEX_LEGACY = /session[_ ](?:id|saved)[:\s]+([a-zA-Z0-9_-]+)/i;
+const SESSION_ID_REGEX_LEGACY = new RegExp(
+  `session[_ ](?:id|saved)[:\\s]+(${HERMES_SESSION_ID_PATTERN})`,
+  "i",
+);
 
 /** Regex to extract token usage from Hermes output. */
 const TOKEN_USAGE_REGEX =
@@ -254,19 +263,21 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
   //   <response text>
   //
   //   session_id: <id>
-  const sessionMatch = stdout.match(SESSION_ID_REGEX);
-  if (sessionMatch?.[1]) {
-    result.sessionId = sessionMatch?.[1] ?? null;
-    // The response is everything before the session_id line
-    const sessionLineIdx = stdout.lastIndexOf("\nsession_id:");
-    if (sessionLineIdx > 0) {
-      result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
-    }
+  const sessionMatch = combined.match(SESSION_ID_REGEX);
+  if (isValidHermesSessionId(sessionMatch?.[1])) {
+    result.sessionId = sessionMatch[1];
+  }
+
+  // Response text always comes from stdout. In quiet mode Hermes may emit the
+  // canonical session line on stderr, so never use its stream location to
+  // decide whether stdout should be cleaned.
+  const sessionLineIdx = stdout.lastIndexOf("\nsession_id:");
+  if (sessionLineIdx > 0) {
+    result.response = cleanResponse(stdout.slice(0, sessionLineIdx));
   } else {
-    // Legacy format (non-quiet mode)
     const legacyMatch = combined.match(SESSION_ID_REGEX_LEGACY);
-    if (legacyMatch?.[1]) {
-      result.sessionId = legacyMatch?.[1] ?? null;
+    if (!result.sessionId && isValidHermesSessionId(legacyMatch?.[1])) {
+      result.sessionId = legacyMatch[1];
     }
     // In non-quiet mode, extract clean response from stdout by
     // filtering out tool lines, system messages, and noise
@@ -397,9 +408,10 @@ export async function execute(
   args.push("--yolo");
 
   // Session resume
-  const prevSessionId = cfgString(
+  const rawSessionId = cfgString(
     (ctx.runtime?.sessionParams as Record<string, unknown> | null)?.sessionId,
   );
+  const prevSessionId = isValidHermesSessionId(rawSessionId) ? rawSessionId : undefined;
   if (persistSession && prevSessionId) {
     args.push("--resume", prevSessionId);
   }
@@ -485,8 +497,12 @@ export async function execute(
     "stdout",
     `[hermes] Exit code: ${result.exitCode ?? "null"}, timed out: ${result.timedOut}\n`,
   );
-  if (parsed.sessionId) {
-    await ctx.onLog("stdout", `[hermes] Session: ${parsed.sessionId}\n`);
+  const parsedSessionId = result.exitCode === 0 && isValidHermesSessionId(parsed.sessionId)
+    ? parsed.sessionId
+    : undefined;
+
+  if (parsedSessionId) {
+    await ctx.onLog("stdout", `[hermes] Session: ${parsedSessionId}\n`);
   }
 
   // ── Build result ───────────────────────────────────────────────────────
@@ -518,15 +534,15 @@ export async function execute(
   // Set resultJson so Paperclip can persist run metadata (used for UI display + auto-comments)
   executionResult.resultJson = {
     result: parsed.response || "",
-    session_id: parsed.sessionId || null,
+    session_id: parsedSessionId || null,
     usage: parsed.usage || null,
     cost_usd: parsed.costUsd ?? null,
   };
 
   // Store session ID for next run
-  if (persistSession && parsed.sessionId) {
-    executionResult.sessionParams = { sessionId: parsed.sessionId };
-    executionResult.sessionDisplayId = parsed.sessionId.slice(0, 16);
+  if (persistSession && parsedSessionId) {
+    executionResult.sessionParams = { sessionId: parsedSessionId };
+    executionResult.sessionDisplayId = parsedSessionId;
   }
 
   return executionResult;

--- a/test/execute-session.test.mjs
+++ b/test/execute-session.test.mjs
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { execute } from "../dist/server/execute.js";
+
+async function makeFakeHermesCommand() {
+  const dir = await mkdtemp(join(tmpdir(), "hermes-adapter-test-"));
+  const command = join(dir, "fake-hermes.mjs");
+  await writeFile(
+    command,
+    `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+if (process.env.HERMES_FAKE_ARGV_FILE) {
+  writeFileSync(process.env.HERMES_FAKE_ARGV_FILE, JSON.stringify(process.argv.slice(2), null, 2));
+}
+if (process.env.HERMES_FAKE_STDOUT) process.stdout.write(process.env.HERMES_FAKE_STDOUT);
+if (process.env.HERMES_FAKE_STDERR) process.stderr.write(process.env.HERMES_FAKE_STDERR);
+process.exit(Number(process.env.HERMES_FAKE_EXIT_CODE || "0"));
+`,
+    "utf8",
+  );
+  await chmod(command, 0o755);
+  return command;
+}
+
+function makeContext(config = {}, runtime = {}) {
+  const logs = [];
+  return {
+    runId: "run-test",
+    config,
+    runtime,
+    agent: {
+      id: "agent-test",
+      name: "Hermes Test Agent",
+      companyId: "company-test",
+      adapterConfig: {},
+    },
+    onLog: async (stream, chunk) => {
+      logs.push({ stream, chunk });
+    },
+    logs,
+  };
+}
+
+test("execute preserves the full Hermes session id as the display id", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const sessionId = "20260518_175454_0af855";
+  const ctx = makeContext({
+    hermesCommand,
+    model: "gpt-5.5",
+    env: {
+      HERMES_FAKE_STDOUT: `Agent finished.\n\nsession_id: ${sessionId}\n`,
+    },
+  });
+
+  const result = await execute(ctx);
+
+  assert.deepEqual(result.sessionParams, { sessionId });
+  assert.equal(result.sessionDisplayId, sessionId);
+  assert.equal(result.resultJson?.session_id, sessionId);
+});
+
+test("execute captures the canonical session id from quiet-mode stderr", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const sessionId = "20260518_175454_0af855";
+  const ctx = makeContext({
+    hermesCommand,
+    model: "gpt-5.5",
+    env: {
+      HERMES_FAKE_STDOUT: "Agent finished.\n",
+      HERMES_FAKE_STDERR: `session_id: ${sessionId}\n`,
+    },
+  });
+
+  const result = await execute(ctx);
+
+  assert.deepEqual(result.sessionParams, { sessionId });
+  assert.equal(result.sessionDisplayId, sessionId);
+  assert.equal(result.resultJson?.session_id, sessionId);
+  assert.equal(result.summary, "Agent finished.");
+});
+
+test("execute ignores invalid session ids parsed from Hermes error/help output", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const ctx = makeContext({
+    hermesCommand,
+    model: "gpt-5.5",
+    env: {
+      HERMES_FAKE_STDERR:
+        "Session not found: from\nUse a session ID from a previous CLI run (hermes sessions list).\n",
+      HERMES_FAKE_EXIT_CODE: "1",
+    },
+  });
+
+  const result = await execute(ctx);
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.sessionParams, undefined);
+  assert.equal(result.sessionDisplayId, undefined);
+  assert.equal(result.resultJson?.session_id, null);
+});
+
+test("execute does not pass invalid persisted session ids to --resume", async () => {
+  const hermesCommand = await makeFakeHermesCommand();
+  const dir = await mkdtemp(join(tmpdir(), "hermes-adapter-argv-"));
+  const argvFile = join(dir, "argv.json");
+  const sessionId = "20260518_175454_0af855";
+  const ctx = makeContext(
+    {
+      hermesCommand,
+      model: "gpt-5.5",
+      env: {
+        HERMES_FAKE_ARGV_FILE: argvFile,
+        HERMES_FAKE_STDOUT: `Recovered.\n\nsession_id: ${sessionId}\n`,
+      },
+    },
+    { sessionParams: { sessionId: "from" } },
+  );
+
+  const result = await execute(ctx);
+  const argv = JSON.parse(await readFile(argvFile, "utf8"));
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.sessionParams?.sessionId, sessionId);
+  assert.equal(argv.includes("--resume"), false);
+  assert.equal(argv.includes("from"), false);
+});


### PR DESCRIPTION
## Summary

Hardens Hermes session parsing and persistence in the standalone Paperclip adapter.

Hermes error/help prose can currently be accepted as session metadata by the permissive legacy parser, invalid persisted values can be passed back through `--resume`, failed executions can publish parsed session state, and `sessionDisplayId` truncates the canonical ID. Together these behaviors can create repeated resume failures and obscure the real session being resumed.

Closes #75.
Closes #127.
Addresses the session-handling half of #125.

## Changes

- Accept only canonical `YYYYMMDD_HHMMSS_<suffix>` Hermes session IDs.
- Read canonical quiet-mode `session_id:` metadata from stdout or stderr while retaining assistant response text from stdout.
- Reject invalid persisted IDs before adding `--resume`.
- Publish session state only after a successful Hermes exit.
- Preserve the full canonical session ID in `sessionDisplayId`.
- Add executable regressions for canonical parsing, stderr metadata, prose false positives, invalid resume state, failed-run persistence, and full display IDs.
- Add the repository's existing Node test command to `package.json`.

## Scope

This PR contains only the session parsing/persistence/display fix. Grok/xAI provider routing from the former combined PR is intentionally split into a separate PR and issue.

Related partial PRs #138 and #149 cover subsets of this contract. This PR also validates already-persisted resume IDs, preserves stdout response extraction when quiet metadata is on stderr, and prevents failed runs from publishing new session state.

## Verification

```text
npm ci
npm test
# 4 passed, 0 failed

npm run typecheck
# passed

npm run build
# passed
```

## Risks

- Session validation is intentionally Hermes-specific. A future Hermes session-ID format change would require updating the pattern and regressions.
- Existing malformed persisted values are ignored rather than passed to Hermes.
- No runtime dependencies or configuration keys change.
