### PR TITLE
fix(provider): route Grok models to xAI OAuth

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -38,6 +38,8 @@ export const VALID_PROVIDERS = [
   "minimax",
   "minimax-cn",
   "kilocode",
+  "xai",
+  "xai-oauth",
 ] as const;
 
 /**
@@ -68,6 +70,9 @@ export const MODEL_PREFIX_PROVIDER_HINTS: [string, string][] = [
   ["kimi", "kimi-coding"],
   // MiniMax
   ["minimax", "minimax"],
+  // xAI / Grok
+  ["grok-", "xai-oauth"],
+  ["grok/", "xai-oauth"],
   // DeepSeek
   ["deepseek", "auto"],
   // Meta Llama

--- a/test/provider-resolution.test.mjs
+++ b/test/provider-resolution.test.mjs
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { VALID_PROVIDERS } from "../dist/shared/constants.js";
+import { inferProviderFromModel, resolveProvider } from "../dist/server/detect-model.js";
+
+test("xAI/Grok providers are valid explicit Hermes providers", () => {
+  assert.equal(VALID_PROVIDERS.includes("xai"), true);
+  assert.equal(VALID_PROVIDERS.includes("xai-oauth"), true);
+  assert.deepEqual(resolveProvider({ explicitProvider: "xai-oauth", model: "grok-4.3" }), {
+    provider: "xai-oauth",
+    resolvedFrom: "adapterConfig",
+  });
+});
+
+test("Grok model names infer xai-oauth instead of falling back to auto", () => {
+  assert.equal(inferProviderFromModel("grok-4.3"), "xai-oauth");
+  assert.equal(inferProviderFromModel("grok/grok-4.3"), "xai-oauth");
+  assert.deepEqual(resolveProvider({ model: "grok-4.3" }), {
+    provider: "xai-oauth",
+    resolvedFrom: "modelInference",
+  });
+});


### PR DESCRIPTION
## Summary

Routes Grok models to Hermes's supported xAI OAuth provider.

The adapter currently omits `xai` and `xai-oauth` from its valid-provider list and has no provider hint for Grok model names. With `provider: auto`, `grok-*` / `grok/...` models therefore fall through instead of selecting the xAI OAuth authentication path.

Closes #185.
Addresses the provider-routing half of #125.

## Changes

- Add `xai` and `xai-oauth` to `VALID_PROVIDERS`.
- Map `grok-` and `grok/` model prefixes to `xai-oauth`.
- Add regressions proving both explicit providers are accepted and both Grok naming forms infer `xai-oauth`.
- Preserve the existing rule that an explicit provider overrides model-name inference.

## Scope

This PR contains only provider resolution. The former combined session-handling changes are now isolated in #184.

## Verification

```text
node --test test/provider-resolution.test.mjs
# 2 passed, 0 failed

npm run typecheck
# passed

npm run build
# passed
```

## Risks

- Grok inference applies only when no explicit provider overrides it.
- The mapping targets `xai-oauth`, matching Hermes's supported Grok OAuth flow.
- No runtime dependencies or configuration keys change.
